### PR TITLE
feat: add character cards with world filter

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "open.api.nexon.com",
+        pathname: "/static/maplestory/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/character/basic/route.ts
+++ b/src/app/api/character/basic/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { Success, Failed } from "@/lib/message";
+import axios, { AxiosError } from "axios";
+
+export async function GET(req: Request) {
+    const apiKey = req.headers.get("x-nxopen-api-key");
+    const { searchParams } = new URL(req.url);
+    const ocid = searchParams.get("ocid");
+
+    if (!apiKey) {
+        return NextResponse.json(Failed("Missing API Key", 500), { status: 500 });
+    }
+
+    if (!ocid) {
+        return NextResponse.json(Failed("Missing ocid", 400), { status: 400 });
+    }
+
+    try {
+        const res = await axios.get(
+            "https://open.api.nexon.com/maplestory/v1/character/basic",
+            {
+                params: { ocid },
+                headers: { "x-nxopen-api-key": apiKey },
+            }
+        );
+
+        return NextResponse.json(
+            Success("캐릭터 조회 성공", 200, res.data),
+            { status: 200 }
+        );
+    } catch (err: unknown) {
+        if (err instanceof AxiosError) {
+            const message = err.response?.data?.error?.message ?? err.message;
+            const status = err.response?.status ?? 500;
+            return NextResponse.json(Failed(message, status), { status });
+        }
+        if (err instanceof Error) {
+            return NextResponse.json(Failed(err.message, 500), { status: 500 });
+        }
+        return NextResponse.json(Failed("Unknown error", 500), { status: 500 });
+    }
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,11 +4,9 @@ import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { supabase } from "@/lib/supabaseClient"
 import { useApiKeyStore } from "@/store/apiKeyStore"
-import { Card } from "@/components/ui/card"
-import { api } from "@/lib/api"
 import { toast } from "sonner"
-import { unwrapOrThrow } from "@/lib/message"
-import { findCharacterList } from "@/fetch/character.fetch";
+import { findCharacterList } from "@/fetch/character.fetch"
+import CharacterCard from "@/components/character-card"
 
 interface CharacterSummary {
     ocid: string
@@ -22,6 +20,7 @@ export default function Home() {
     const router = useRouter()
     const setApiKey = useApiKeyStore((s) => s.setApiKey)
     const [characters, setCharacters] = useState<CharacterSummary[]>([])
+    const [worldFilter, setWorldFilter] = useState("전체월드")
 
     useEffect(() => {
         const load = async () => {
@@ -50,16 +49,26 @@ export default function Home() {
         load()
     }, [router, setApiKey])
 
+    const worlds = ["전체월드", ...Array.from(new Set(characters.map(c => c.world_name)))]
+
     return (
-        <main className="p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-            {characters?.map((c) => (
-                <Card key={c.ocid} className="p-4">
-                    <p className="font-bold">{c.character_name}</p>
-                    <p className="text-sm text-muted-foreground">
-                        Lv.{c.character_level} {c.character_class} ({c.world_name})
-                    </p>
-                </Card>
-            ))}
-        </main>
+        <div className="p-4">
+            <select
+                value={worldFilter}
+                onChange={(e) => setWorldFilter(e.target.value)}
+                className="mb-4 rounded border p-2"
+            >
+                {worlds.map(world => (
+                    <option key={world} value={world}>{world}</option>
+                ))}
+            </select>
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                {characters
+                    .filter(c => worldFilter === "전체월드" || c.world_name === worldFilter)
+                    .map((c) => (
+                        <CharacterCard key={c.ocid} character={c} />
+                    ))}
+            </div>
+        </div>
     )
 }

--- a/src/components/character-card.tsx
+++ b/src/components/character-card.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { Card } from "@/components/ui/card";
+import { findCharacterBasic } from "@/fetch/character.fetch";
+
+interface CharacterSummary {
+    ocid: string;
+    character_name: string;
+    world_name: string;
+    character_class: string;
+    character_level: number;
+}
+
+export default function CharacterCard({ character }: { character: CharacterSummary }) {
+    const [image, setImage] = useState<string | null>(null);
+
+    useEffect(() => {
+        findCharacterBasic(character.ocid).then(data => {
+            setImage(data.character_image);
+        }).catch(() => {});
+    }, [character.ocid]);
+
+    return (
+        <Card className="p-4 flex flex-col">
+            <div className="relative w-full h-60 mb-4">
+                {image && (
+                    <Image
+                        src={image}
+                        alt={character.character_name}
+                        fill
+                        className="object-contain"
+                        sizes="(max-width: 768px) 100vw, 33vw"
+                    />
+                )}
+            </div>
+            <div className="mt-auto flex items-end justify-between">
+                <div>
+                    <p className="font-bold">{character.character_name}</p>
+                    <p className="text-sm text-muted-foreground">{character.character_class}</p>
+                </div>
+                <p className="text-red-500 text-2xl font-bold">{character.character_level}</p>
+            </div>
+        </Card>
+    );
+}

--- a/src/fetch/character.fetch.ts
+++ b/src/fetch/character.fetch.ts
@@ -8,3 +8,10 @@ export const findCharacterList = async () => {
     });
     return response.data;
 };
+export const findCharacterBasic = async (ocid: string) => {
+    const apiKey = useApiKeyStore.getState().apiKey;
+    const response = await axios.get(`/api/character/basic?ocid=${ocid}`, {
+        headers: { "x-nxopen-api-key": apiKey ?? "" },
+    });
+    return response.data;
+};


### PR DESCRIPTION
## Summary
- allow filtering characters by world selection
- add character card component that loads images
- expose character basic API endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Can't resolve 'tw-animate-css')*


------
https://chatgpt.com/codex/tasks/task_e_68c196af68708324adbc4e8aa32b645c