### PR TITLE
Replace LoadingButton with Button on auth forms

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { supabase } from '@/lib/supabaseClient';
 import { useUserStore } from '@/store/userStore';
-import { LoadingButton } from '@/components/ui/loading-button';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
@@ -77,18 +77,18 @@ export default function SignInPage() {
               required
             />
           </div>
-          <LoadingButton type="submit" className="w-full" isLoading={loading}>
-            Sign In
-          </LoadingButton>
-          <LoadingButton
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Sign In...' : 'Sign In'}
+          </Button>
+          <Button
             type="button"
             variant="outline"
             className="w-full"
             onClick={handleGoogle}
-            isLoading={googleLoading}
+            disabled={googleLoading}
           >
-            Sign in with Google
-          </LoadingButton>
+            {googleLoading ? 'Sign in with Google...' : 'Sign in with Google'}
+          </Button>
           <p className="text-sm text-center">
             Don&apos;t have an account?{' '}
             <Link href="/sign_up" className="underline">

--- a/src/app/(auth)/sign_up/page.tsx
+++ b/src/app/(auth)/sign_up/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { supabase } from '@/lib/supabaseClient';
 import { useUserStore } from '@/store/userStore';
-import { LoadingButton } from '@/components/ui/loading-button';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
@@ -87,18 +87,18 @@ export default function SignUpPage() {
               required
             />
           </div>
-          <LoadingButton type="submit" className="w-full" isLoading={loading}>
-            Create account
-          </LoadingButton>
-          <LoadingButton
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Create account...' : 'Create account'}
+          </Button>
+          <Button
             type="button"
             variant="outline"
             className="w-full"
             onClick={handleGoogle}
-            isLoading={googleLoading}
+            disabled={googleLoading}
           >
-            Sign up with Google
-          </LoadingButton>
+            {googleLoading ? 'Sign up with Google...' : 'Sign up with Google'}
+          </Button>
           <p className="text-sm text-center">
             Already have an account?{' '}
             <Link href="/sign_in" className="underline">


### PR DESCRIPTION
## Summary
- replace LoadingButton with Button on sign-in page, showing disabled state and ellipsis
- replace LoadingButton with Button on sign-up page, showing disabled state and ellipsis

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c228c084c08324a10f77e4e9d078ae