### PR TITLE
feat: add spinner for page loading

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from '@/components/ui/spinner';
+
+export default function Loading() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/src/components/Character/CharacterDetail.tsx
+++ b/src/components/Character/CharacterDetail.tsx
@@ -25,6 +25,7 @@ import {
     findCharacterOtherStat,
     findCharacterRingExchange,
 } from '@/fetch/character.fetch';
+import { Spinner } from '@/components/ui/spinner';
 
 interface CharacterBasic {
     character_image?: string;
@@ -113,7 +114,12 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         load();
     }, [ocid]);
 
-    if (!data) return <div className="p-4">Loading...</div>;
+    if (!data)
+        return (
+            <div className="flex p-4 justify-center">
+                <Spinner />
+            </div>
+        );
 
     const basic = data.basic as CharacterBasic;
 

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Spinner = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent',
+      className,
+    )}
+    {...props}
+  />
+);
+
+export { Spinner };


### PR DESCRIPTION
## Summary
- replace default page Loading text with centered spinner
- add reusable Spinner component
- show spinner during character details fetch

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2721580048324aa7ff30c62f8c22f