### PR TITLE
refactor: centralize interfaces and remove duplicates

### DIFF
--- a/src/app/(main)/character_list/page.tsx
+++ b/src/app/(main)/character_list/page.tsx
@@ -10,25 +10,18 @@ import { addFavorite, getFavorites, removeFavorite } from "@/fetchs/favorite.fet
 import CharacterCardSkeleton from "@/components/character/CharacterCardSkeleton";
 import CharacterCell from "@/components/character/CharacterCell";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ICharacterSummary } from "@/interface/ICharacterSummary";
 
-interface CharacterSummary {
-    ocid: string;
-    character_name: string;
-    world_name: string;
-    character_class: string;
-    character_level: number;
-}
-
-interface CharacterListResponse {
+interface ICharacterListResponse {
     message: string;
     status: number;
-    characters: CharacterSummary[];
+    characters: ICharacterSummary[];
 }
 
 const CharacterList = () => {
     const setApiKey = useUserStore((s) => s.setApiKey);
-    const [characters, setCharacters] = useState<CharacterSummary[]>([]);
-    const [displayCharacters, setDisplayCharacters] = useState<CharacterSummary[]>([]);
+    const [characters, setCharacters] = useState<ICharacterSummary[]>([]);
+    const [displayCharacters, setDisplayCharacters] = useState<ICharacterSummary[]>([]);
     const [worldFilter, setWorldFilter] = useState("전체월드");
     const [favorites, setFavorites] = useState<string[]>([]);
     const [userId, setUserId] = useState<string | null>(null);
@@ -50,7 +43,7 @@ const CharacterList = () => {
             if (key) setApiKey(key);
 
             try {
-                const res: CharacterListResponse = await findCharacterList();
+                const res: ICharacterListResponse = await findCharacterList();
                 const list = res.characters ?? [];
                 const sorted = list.sort((a, b) => b.character_level - a.character_level);
 

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -11,15 +11,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { addFavorite, getFavorites, removeFavorite } from "@/fetchs/favorite.fetch";
 import { findCharacterBasic } from "@/fetchs/character.fetch";
-
-interface ICharacterSummary {
-    ocid: string;
-    character_name: string;
-    world_name: string;
-    character_class: string;
-    character_level: number;
-    image?: string;
-}
+import { ICharacterSummary } from "@/interface/ICharacterSummary";
 
 const Home = () => {
     const [user, setUser] = useState<{ id: string; email?: string } | null>(null);

--- a/src/app/api/character/list/route.ts
+++ b/src/app/api/character/list/route.ts
@@ -1,19 +1,12 @@
 import axios, { AxiosError } from "axios";
 import { Get } from "@/lib/fetch";
 import { Failed, Success } from "@/lib/message";
+import { ICharacterSummary } from "@/interface/ICharacterSummary";
 
-interface CharacterSummary {
-    ocid: string;
-    character_name: string;
-    world_name: string;
-    character_class: string;
-    character_level: number;
-}
-
-interface CharacterListResponse {
+interface ICharacterListApiResponse {
     account_list: {
         account_id: string;
-        character_list: CharacterSummary[];
+        character_list: ICharacterSummary[];
     }[];
 }
 
@@ -24,7 +17,7 @@ export const GET = async (req: Request) => {
         if (!apiKey) return Failed("Missing API Key", 500);
 
         try {
-            const res = await axios.get<CharacterListResponse>(
+            const res = await axios.get<ICharacterListApiResponse>(
                 "https://open.api.nexon.com/maplestory/v1/character/list",
                 {
                     headers: { "x-nxopen-api-key": apiKey },

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -6,18 +6,10 @@ import { Star } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { findCharacterBasic } from "@/fetchs/character.fetch";
 import { Button } from "@/components/ui/button";
+import { ICharacterSummary } from "@/interface/ICharacterSummary";
 
-interface CharacterSummary {
-    ocid: string;
-    character_name: string;
-    world_name: string;
-    character_class: string;
-    character_level: number;
-    image?: string;
-}
-
-interface Props {
-    character: CharacterSummary;
+interface ICharacterCardProps {
+    character: ICharacterSummary;
     isFavorite?: boolean;
     onToggleFavorite?: () => void;
     onSelect?: () => void;
@@ -28,7 +20,7 @@ const CharacterCard = ({
     isFavorite,
     onToggleFavorite,
     onSelect,
-}: Props) => {
+}: ICharacterCardProps) => {
     const [image, setImage] = useState<string | null>(character.image ?? null);
     const ref = useRef<HTMLDivElement>(null);
 
@@ -67,7 +59,6 @@ const CharacterCard = ({
                 <Button
                     variant='ghost'
                     onClick={(e) => {
-                        console.log("????")
                         e.preventDefault();
                         e.stopPropagation(); // 부모 onClick 방지
                         onToggleFavorite?.();

--- a/src/components/character/CharacterCell.tsx
+++ b/src/components/character/CharacterCell.tsx
@@ -1,21 +1,14 @@
 import CharacterCard from "@/components/character/CharacterCard";
 import { useRouter } from "next/navigation";
+import { ICharacterSummary } from "@/interface/ICharacterSummary";
 
-interface CharacterSummary {
-    ocid: string;
-    character_name: string;
-    world_name: string;
-    character_class: string;
-    character_level: number;
-}
-
-interface Props {
-    character: CharacterSummary;
+interface ICharacterCellProps {
+    character: ICharacterSummary;
     favorites: string[];
     toggleFavorite: (ocid: string) => void;
 }
 
-const CharacterCell = ({ character, favorites, toggleFavorite }: Props) => {
+const CharacterCell = ({ character, favorites, toggleFavorite }: ICharacterCellProps) => {
     const router = useRouter();
 
     return (

--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -8,19 +8,15 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { StatCard } from "@/components/character/card/StatCard";
 import { PopularityCard } from "@/components/character/card/PopularityCard";
 import { HyperStatCard } from "@/components/character/card/HyperStatCard";
-import { Stage1Data, Stage2Data, Stage3Data, Stage4Data } from "@/interface/character";
-
-interface CharacterBasic {
-    character_image?: string;
-    character_name: string;
-}
+import { IStage1Data, IStage2Data, IStage3Data, IStage4Data } from "@/interface/character";
+import { ICharacterResponse } from "@/interface/ICharacterResponse";
 
 const CharacterDetail = ({ ocid }: { ocid: string }) => {
-    const [basic, setBasic] = useState<CharacterBasic | null>(null);
-    const [stage1, setStage1] = useState<Stage1Data>({})
-    const [stage2, setStage2] = useState<Stage2Data>({})
-    const [stage3, setStage3] = useState<Stage3Data>({})
-    const [stage4, setStage4] = useState<Stage4Data>({})
+    const [basic, setBasic] = useState<Pick<ICharacterResponse, 'character_image' | 'character_name'> | null>(null);
+    const [stage1, setStage1] = useState<IStage1Data>({})
+    const [stage2, setStage2] = useState<IStage2Data>({})
+    const [stage3, setStage3] = useState<IStage3Data>({})
+    const [stage4, setStage4] = useState<IStage4Data>({})
 
     useEffect(() => {
         if (!ocid) return;

--- a/src/components/character/card/HyperStatCard.tsx
+++ b/src/components/character/card/HyperStatCard.tsx
@@ -1,21 +1,8 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ICharacterHyperStat } from "@/interface/character";
 
-interface HyperStat {
-    stat_type: string
-    stat_point: number | null
-    stat_level: number
-    stat_increase: string | null
-}
-
-interface HyperResponse {
-    use_preset_no: string
-    hyper_stat_preset_1: HyperStat[]
-    hyper_stat_preset_2: HyperStat[]
-    hyper_stat_preset_3: HyperStat[]
-}
-
-export function HyperStatCard({ hyper }: { hyper: HyperResponse }) {
+export function HyperStatCard({ hyper }: { hyper: ICharacterHyperStat }) {
     const presets = [
         { key: "1", label: "프리셋 1", stats: hyper.hyper_stat_preset_1 },
         { key: "2", label: "프리셋 2", stats: hyper.hyper_stat_preset_2 },

--- a/src/components/character/card/StatCard.tsx
+++ b/src/components/character/card/StatCard.tsx
@@ -1,13 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
+import { ICharacterStat } from "@/interface/character"
 
-interface StatResponse {
-    character_class: string
-    final_stat: { stat_name: string; stat_value: string }[]
-}
-
-export function StatCard({ stat }: { stat: StatResponse }) {
+export function StatCard({ stat }: { stat: ICharacterStat }) {
     const highlights = ["전투력", "보스 몬스터 데미지", "크리티컬 확률", "크리티컬 데미지"]
 
     return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -25,13 +25,13 @@ const buttonVariants = cva(
   }
 );
 
-export interface ButtonProps
+export interface IButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (

--- a/src/components/ui/loading-button.tsx
+++ b/src/components/ui/loading-button.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { Button, ButtonProps } from '@/components/ui/button';
+import { Button, IButtonProps } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 
-interface LoadingButtonProps extends ButtonProps {
+interface ILoadingButtonProps extends IButtonProps {
   isLoading?: boolean;
 }
 
-const LoadingButton = React.forwardRef<HTMLButtonElement, LoadingButtonProps>(
+const LoadingButton = React.forwardRef<HTMLButtonElement, ILoadingButtonProps>(
   ({ isLoading, children, disabled, ...props }, ref) => {
     return (
       <Button ref={ref} disabled={isLoading || disabled} {...props}>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -7,7 +7,7 @@ const Sheet = SheetPrimitive.Root;
 const SheetTrigger = SheetPrimitive.Trigger;
 const SheetClose = SheetPrimitive.Close;
 
-interface SheetPortalProps extends SheetPrimitive.DialogPortalProps {
+interface ISheetPortalProps extends SheetPrimitive.DialogPortalProps {
   className?: string;
 }
 
@@ -15,7 +15,7 @@ const SheetPortal = ({
   className,
   children,
   ...props
-}: SheetPortalProps) => (
+}: ISheetPortalProps) => (
   <SheetPrimitive.Portal {...props}>
     <div className={cn("fixed inset-0 z-50 flex", className)}>{children}</div>
   </SheetPrimitive.Portal>

--- a/src/interface/ICharacterSummary.ts
+++ b/src/interface/ICharacterSummary.ts
@@ -1,0 +1,8 @@
+export interface ICharacterSummary {
+    ocid: string;
+    character_name: string;
+    world_name: string;
+    character_class: string;
+    character_level: number;
+    image?: string;
+}

--- a/src/interface/character.ts
+++ b/src/interface/character.ts
@@ -1,55 +1,55 @@
 /* -------------------- Stage1 -------------------- */
-export interface CharacterStat {
+export interface ICharacterStat {
     date: string
     character_class: string
     final_stat: { stat_name: string; stat_value: string }[]
     remain_ap: number
 }
 
-export interface CharacterPopularity {
+export interface ICharacterPopularity {
     date: string
     popularity: number
 }
 
-export interface HyperStatInfo {
+export interface IHyperStatInfo {
     stat_type: string
     stat_point: number
     stat_level: number
     stat_increase: string
 }
 
-export interface CharacterHyperStat {
+export interface ICharacterHyperStat {
     date: string
     character_class: string
     use_preset_no: string
     use_available_hyper_stat: number
-    hyper_stat_preset_1: HyperStatInfo[]
+    hyper_stat_preset_1: IHyperStatInfo[]
     hyper_stat_preset_1_remain_point: number
-    hyper_stat_preset_2: HyperStatInfo[]
+    hyper_stat_preset_2: IHyperStatInfo[]
     hyper_stat_preset_2_remain_point: number
-    hyper_stat_preset_3: HyperStatInfo[]
+    hyper_stat_preset_3: IHyperStatInfo[]
     hyper_stat_preset_3_remain_point: number
 }
 
-export interface Stage1Data {
-    stat?: CharacterStat
-    popularity?: CharacterPopularity
-    hyper?: CharacterHyperStat
+export interface IStage1Data {
+    stat?: ICharacterStat
+    popularity?: ICharacterPopularity
+    hyper?: ICharacterHyperStat
 }
 
 /* -------------------- Stage2 -------------------- */
-export interface CharacterItemEquipment {
+export interface ICharacterItemEquipment {
     date: string
     character_gender: string
     character_class: string
     preset_no: number
-    item_equipment: ItemEquipment[]
-    item_equipment_preset_1: ItemEquipment[]
-    item_equipment_preset_2: ItemEquipment[]
-    item_equipment_preset_3: ItemEquipment[]
+    item_equipment: IItemEquipment[]
+    item_equipment_preset_1: IItemEquipment[]
+    item_equipment_preset_2: IItemEquipment[]
+    item_equipment_preset_3: IItemEquipment[]
 }
 
-export interface ItemEquipment {
+export interface IItemEquipment {
     item_equipment_part: string
     item_equipment_slot: string
     item_name: string
@@ -61,19 +61,19 @@ export interface ItemEquipment {
     // ... (추가 옵션들 필요 시 확장)
 }
 
-export interface CharacterCashItemEquipment {
+export interface ICharacterCashItemEquipment {
     date: string
     character_gender: string
     character_class: string
     character_look_mode: string
     preset_no: number
-    cash_item_equipment_base: CashItem[]
-    cash_item_equipment_preset_1: CashItem[]
-    cash_item_equipment_preset_2: CashItem[]
-    cash_item_equipment_preset_3: CashItem[]
+    cash_item_equipment_base: ICashItem[]
+    cash_item_equipment_preset_1: ICashItem[]
+    cash_item_equipment_preset_2: ICashItem[]
+    cash_item_equipment_preset_3: ICashItem[]
 }
 
-export interface CashItem {
+export interface ICashItem {
     cash_item_equipment_part: string
     cash_item_equipment_slot: string
     cash_item_name: string
@@ -82,7 +82,7 @@ export interface CashItem {
     // ... (option, expire 등 필요시 확장)
 }
 
-export interface CharacterSymbolEquipment {
+export interface ICharacterSymbolEquipment {
     date: string
     character_class: string
     symbol: {
@@ -101,7 +101,7 @@ export interface CharacterSymbolEquipment {
     }[]
 }
 
-export interface CharacterSetEffect {
+export interface ICharacterSetEffect {
     date: string
     set_effect: {
         set_name: string
@@ -111,7 +111,7 @@ export interface CharacterSetEffect {
     }[]
 }
 
-export interface CharacterSkill {
+export interface ICharacterSkill {
     date: string
     character_class: string
     character_skill: {
@@ -123,7 +123,7 @@ export interface CharacterSkill {
     }[]
 }
 
-export interface CharacterLinkSkill {
+export interface ICharacterLinkSkill {
     date: string
     character_class: string
     character_link_skill: {
@@ -135,17 +135,17 @@ export interface CharacterLinkSkill {
     }[]
 }
 
-export interface Stage2Data {
-    itemEquip?: CharacterItemEquipment
-    cashEquip?: CharacterCashItemEquipment
-    symbolEquip?: CharacterSymbolEquipment
-    setEffect?: CharacterSetEffect
-    skill?: CharacterSkill[]
-    linkSkill?: CharacterLinkSkill
+export interface IStage2Data {
+    itemEquip?: ICharacterItemEquipment
+    cashEquip?: ICharacterCashItemEquipment
+    symbolEquip?: ICharacterSymbolEquipment
+    setEffect?: ICharacterSetEffect
+    skill?: ICharacterSkill[]
+    linkSkill?: ICharacterLinkSkill
 }
 
 /* -------------------- Stage3 -------------------- */
-export interface CharacterVMatrix {
+export interface ICharacterVMatrix {
     date: string
     character_class: string
     character_v_core_equipment: {
@@ -161,7 +161,7 @@ export interface CharacterVMatrix {
     character_v_matrix_remain_slot_upgrade_point: number
 }
 
-export interface CharacterHexaMatrix {
+export interface ICharacterHexaMatrix {
     date: string
     character_hexa_core_equipment: {
         hexa_core_name: string
@@ -171,15 +171,15 @@ export interface CharacterHexaMatrix {
     }[]
 }
 
-export interface CharacterHexaMatrixStat {
+export interface ICharacterHexaMatrixStat {
     date: string
     character_class: string
-    character_hexa_stat_core: HexaStatCore[]
-    character_hexa_stat_core_2: HexaStatCore[]
-    character_hexa_stat_core_3: HexaStatCore[]
+    character_hexa_stat_core: IHexaStatCore[]
+    character_hexa_stat_core_2: IHexaStatCore[]
+    character_hexa_stat_core_3: IHexaStatCore[]
 }
 
-export interface HexaStatCore {
+export interface IHexaStatCore {
     slot_id: string
     main_stat_name: string
     sub_stat_name_1: string
@@ -190,7 +190,7 @@ export interface HexaStatCore {
     stat_grade: number
 }
 
-export interface CharacterDojang {
+export interface ICharacterDojang {
     date: string
     character_class: string
     world_name: string
@@ -199,14 +199,14 @@ export interface CharacterDojang {
     dojang_best_time: number
 }
 
-export interface RingExchangeSkillEquipment {
+export interface IRingExchangeSkillEquipment {
     date: string
     character_class: string
     special_ring_exchange_name: string
     special_ring_exchange_level: number
 }
 
-export interface CharacterOtherStat {
+export interface ICharacterOtherStat {
     date: string
     other_stat: {
         other_stat_type: string
@@ -214,17 +214,17 @@ export interface CharacterOtherStat {
     }[]
 }
 
-export interface Stage3Data {
-    hexaMatrix?: CharacterHexaMatrix
-    hexaStat?: CharacterHexaMatrixStat
-    vMatrix?: CharacterVMatrix
-    dojang?: CharacterDojang
-    ring?: RingExchangeSkillEquipment
-    otherStat?: CharacterOtherStat
+export interface IStage3Data {
+    hexaMatrix?: ICharacterHexaMatrix
+    hexaStat?: ICharacterHexaMatrixStat
+    vMatrix?: ICharacterVMatrix
+    dojang?: ICharacterDojang
+    ring?: IRingExchangeSkillEquipment
+    otherStat?: ICharacterOtherStat
 }
 
 /* -------------------- Stage4 -------------------- */
-export interface CharacterBeautyEquipment {
+export interface ICharacterBeautyEquipment {
     date: string
     character_gender: string
     character_class: string
@@ -249,7 +249,7 @@ export interface CharacterBeautyEquipment {
     }
 }
 
-export interface CharacterAndroidEquipment {
+export interface ICharacterAndroidEquipment {
     date: string
     android_name: string
     android_icon: string
@@ -259,7 +259,7 @@ export interface CharacterAndroidEquipment {
     android_skin?: { skin_name: string; color_style: string }
 }
 
-export interface CharacterPetEquipment {
+export interface ICharacterPetEquipment {
     date: string
     pet_1_name: string
     pet_1_icon: string
@@ -267,7 +267,7 @@ export interface CharacterPetEquipment {
     // ... (펫2, 펫3도 동일 구조)
 }
 
-export interface CharacterPropensity {
+export interface ICharacterPropensity {
     date: string
     charisma_level: number
     sensibility_level: number
@@ -277,7 +277,7 @@ export interface CharacterPropensity {
     charm_level: number
 }
 
-export interface CharacterAbility {
+export interface ICharacterAbility {
     date: string
     ability_preset_no: number
     ability_info: {
@@ -287,10 +287,10 @@ export interface CharacterAbility {
     }[]
 }
 
-export interface Stage4Data {
-    beauty?: CharacterBeautyEquipment
-    android?: CharacterAndroidEquipment
-    pet?: CharacterPetEquipment
-    propensity?: CharacterPropensity
-    ability?: CharacterAbility
+export interface IStage4Data {
+    beauty?: ICharacterBeautyEquipment
+    android?: ICharacterAndroidEquipment
+    pet?: ICharacterPetEquipment
+    propensity?: ICharacterPropensity
+    ability?: ICharacterAbility
 }

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,17 +1,17 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-interface User {
+interface IUser {
     apiKey: string | null;
 }
 
-interface UserState {
-    user: User;
-    setUser: (user: Partial<User>) => void;
+interface IUserState {
+    user: IUser;
+    setUser: (user: Partial<IUser>) => void;
     setApiKey: (key: string) => void;
 }
 
-export const useUserStore = create<UserState>()(persist((set) => ({
+export const useUserStore = create<IUserState>()(persist((set) => ({
         user: { apiKey: null },
         setUser: (user) =>
             set((state) => ({ user: { ...state.user, ...user } })),


### PR DESCRIPTION
## Summary
- move shared character summary to dedicated interface module
- prefix interfaces with `I` and consolidate repeated definitions
- update components to consume common interfaces

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c28a5d292c8324a9ffb7f8edd1463a