### PR TITLE
refactor: manage character detail with zustand

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -1,79 +1,29 @@
 'use client'
 
-import React, { unstable_ViewTransition as ViewTransition, useEffect, useState } from 'react';
+import React, { unstable_ViewTransition as ViewTransition, useEffect } from 'react';
 import Image from 'next/image';
-import { findCharacterAbility, findCharacterAndroidEquipment, findCharacterBasic, findCharacterBeautyEquipment, findCharacterCashItemEquipment, findCharacterDojang, findCharacterHexaMatrix, findCharacterHexaMatrixStat, findCharacterHyperStat, findCharacterItemEquipment, findCharacterLinkSkill, findCharacterOtherStat, findCharacterPetEquipment, findCharacterPopularity, findCharacterPropensity, findCharacterRingExchange, findCharacterSetEffect, findCharacterSkill, findCharacterStat, findCharacterSymbolEquipment, findCharacterVMatrix, } from '@/fetchs/character.fetch';
 import { Spinner } from '@/components/ui/spinner';
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { StatCard } from "@/components/character/card/StatCard";
 import { PopularityCard } from "@/components/character/card/PopularityCard";
 import { HyperStatCard } from "@/components/character/card/HyperStatCard";
-import { IStage1Data, IStage2Data, IStage3Data, IStage4Data } from "@/interface/character";
-import { ICharacterResponse } from "@/interface/ICharacterResponse";
+import { useCharacterStore } from "@/store/characterStore";
 
 const CharacterDetail = ({ ocid }: { ocid: string }) => {
-    const [basic, setBasic] = useState<Pick<ICharacterResponse, 'character_image' | 'character_name'> | null>(null);
-    const [stage1, setStage1] = useState<IStage1Data>({})
-    const [stage2, setStage2] = useState<IStage2Data>({})
-    const [stage3, setStage3] = useState<IStage3Data>({})
-    const [stage4, setStage4] = useState<IStage4Data>({})
+    const {
+        basic,
+        stage1,
+        stage2,
+        stage3,
+        stage4,
+        loadCharacter,
+        reset,
+    } = useCharacterStore();
 
     useEffect(() => {
-        if (!ocid) return;
-
-        const load = async () => {
-            try {
-                // 필수 정보
-                const [basicRes, stat, popularity, hyper] = await Promise.all([
-                    findCharacterBasic(ocid),
-                    findCharacterStat(ocid),
-                    findCharacterPopularity(ocid),
-                    findCharacterHyperStat(ocid),
-                ]);
-                setBasic(basicRes);
-                setStage1({ stat, popularity, hyper });
-
-                // 장비/스킬
-                const grades = ["0", "1", "2", "3", "4", "5", "6", "hyperpassive", "hyperactive"]
-                const [itemEquip, cashEquip, symbolEquip, setEffect, skill, linkSkill] =
-                    await Promise.all([
-                        findCharacterItemEquipment(ocid),
-                        findCharacterCashItemEquipment(ocid),
-                        findCharacterSymbolEquipment(ocid),
-                        findCharacterSetEffect(ocid),
-                        Promise.all(grades.map((g) => findCharacterSkill(ocid, g))),
-                        findCharacterLinkSkill(ocid),
-                    ]);
-                setStage2({ itemEquip, cashEquip, symbolEquip, setEffect, skill, linkSkill });
-
-                // 심화
-                const [hexaMatrix, hexaStat, vMatrix, dojang, ring, otherStat] =
-                    await Promise.all([
-                        findCharacterHexaMatrix(ocid),
-                        findCharacterHexaMatrixStat(ocid),
-                        findCharacterVMatrix(ocid),
-                        findCharacterDojang(ocid),
-                        findCharacterRingExchange(ocid),
-                        findCharacterOtherStat(ocid),
-                    ]);
-                setStage3({ hexaMatrix, hexaStat, vMatrix, dojang, ring, otherStat });
-
-                // 꾸미기/기타
-                const [beauty, android, pet, propensity, ability] = await Promise.all([
-                    findCharacterBeautyEquipment(ocid),
-                    findCharacterAndroidEquipment(ocid),
-                    findCharacterPetEquipment(ocid),
-                    findCharacterPropensity(ocid),
-                    findCharacterAbility(ocid),
-                ]);
-                setStage4({ beauty, android, pet, propensity, ability });
-            } catch (err) {
-                console.error('캐릭터 정보 로딩 실패:', err);
-            }
-        };
-
-        load();
-    }, [ocid]);
+        loadCharacter(ocid);
+        return () => reset();
+    }, [ocid, loadCharacter, reset]);
 
     return (
         <ViewTransition enter="fade" exit="fade">

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -1,0 +1,90 @@
+import { create } from "zustand";
+import {
+    findCharacterAbility,
+    findCharacterAndroidEquipment,
+    findCharacterBasic,
+    findCharacterBeautyEquipment,
+    findCharacterCashItemEquipment,
+    findCharacterDojang,
+    findCharacterHexaMatrix,
+    findCharacterHexaMatrixStat,
+    findCharacterHyperStat,
+    findCharacterItemEquipment,
+    findCharacterLinkSkill,
+    findCharacterOtherStat,
+    findCharacterPetEquipment,
+    findCharacterPopularity,
+    findCharacterPropensity,
+    findCharacterRingExchange,
+    findCharacterSetEffect,
+    findCharacterSkill,
+    findCharacterStat,
+    findCharacterSymbolEquipment,
+    findCharacterVMatrix,
+} from "@/fetchs/character.fetch";
+import { ICharacterResponse } from "@/interface/ICharacterResponse";
+import { IStage1Data, IStage2Data, IStage3Data, IStage4Data } from "@/interface/character";
+
+interface CharacterState {
+    basic: Pick<ICharacterResponse, "character_image" | "character_name"> | null;
+    stage1: IStage1Data;
+    stage2: IStage2Data;
+    stage3: IStage3Data;
+    stage4: IStage4Data;
+    loadCharacter: (ocid: string) => Promise<void>;
+    reset: () => void;
+}
+
+export const useCharacterStore = create<CharacterState>((set) => ({
+    basic: null,
+    stage1: {},
+    stage2: {},
+    stage3: {},
+    stage4: {},
+    loadCharacter: async (ocid: string) => {
+        if (!ocid) return;
+        try {
+            const [basicRes, stat, popularity, hyper] = await Promise.all([
+                findCharacterBasic(ocid),
+                findCharacterStat(ocid),
+                findCharacterPopularity(ocid),
+                findCharacterHyperStat(ocid),
+            ]);
+            set({ basic: basicRes, stage1: { stat, popularity, hyper } });
+
+            const grades = ["0", "1", "2", "3", "4", "5", "6", "hyperpassive", "hyperactive"];
+            const [itemEquip, cashEquip, symbolEquip, setEffect, skill, linkSkill] = await Promise.all([
+                findCharacterItemEquipment(ocid),
+                findCharacterCashItemEquipment(ocid),
+                findCharacterSymbolEquipment(ocid),
+                findCharacterSetEffect(ocid),
+                Promise.all(grades.map((g) => findCharacterSkill(ocid, g))),
+                findCharacterLinkSkill(ocid),
+            ]);
+            set({ stage2: { itemEquip, cashEquip, symbolEquip, setEffect, skill, linkSkill } });
+
+            const [hexaMatrix, hexaStat, vMatrix, dojang, ring, otherStat] = await Promise.all([
+                findCharacterHexaMatrix(ocid),
+                findCharacterHexaMatrixStat(ocid),
+                findCharacterVMatrix(ocid),
+                findCharacterDojang(ocid),
+                findCharacterRingExchange(ocid),
+                findCharacterOtherStat(ocid),
+            ]);
+            set({ stage3: { hexaMatrix, hexaStat, vMatrix, dojang, ring, otherStat } });
+
+            const [beauty, android, pet, propensity, ability] = await Promise.all([
+                findCharacterBeautyEquipment(ocid),
+                findCharacterAndroidEquipment(ocid),
+                findCharacterPetEquipment(ocid),
+                findCharacterPropensity(ocid),
+                findCharacterAbility(ocid),
+            ]);
+            set({ stage4: { beauty, android, pet, propensity, ability } });
+        } catch (err) {
+            console.error("캐릭터 정보 로딩 실패:", err);
+        }
+    },
+    reset: () => set({ basic: null, stage1: {}, stage2: {}, stage3: {}, stage4: {} }),
+}));
+


### PR DESCRIPTION
## Summary
- manage character details with a dedicated zustand store
- simplify CharacterDetail component to use the centralized store

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npx tsc --noEmit` (fails: Cannot find module '@radix-ui/react-scroll-area')

------
https://chatgpt.com/codex/tasks/task_e_68c28eb56ff08324acdbd8eee39c9620