### PR TITLE
feat: show data sections as cards

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -8,6 +8,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { StatCard } from "@/components/character/card/StatCard";
 import { PopularityCard } from "@/components/character/card/PopularityCard";
 import { HyperStatCard } from "@/components/character/card/HyperStatCard";
+import { JsonCard } from "@/components/character/card/JsonCard";
 import { characterDetailStore } from "@/store/characterDetailStore";
 import { toast } from "sonner";
 
@@ -148,7 +149,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                     {popularity && <PopularityCard popularity={popularity.popularity}/>}
                     {hyper && <HyperStatCard hyper={hyper}/>}
 
-                    {/* 장비 / 스킬 - 카드 UI 미구현으로 JSON 프리뷰 */}
+                    {/* 장비 / 스킬 */}
                     {Object.entries({
                         itemEquip,
                         cashEquip,
@@ -157,15 +158,10 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                         skill,
                         linkSkill,
                     }).map(([key, value]) => (
-                        <section key={key} className='w-full'>
-                            <h2 className="text-xl font-bold mb-2">{key}</h2>
-                            <pre className="text-sm bg-muted p-2 rounded overflow-x-auto">
-                                {JSON.stringify(value, null, 2)}
-                            </pre>
-                        </section>
+                        <JsonCard key={key} title={key} data={value} />
                     ))}
 
-                    {/* 심화 - JSON 프리뷰 */}
+                    {/* 심화 */}
                     {Object.entries({
                         hexaMatrix,
                         hexaStat,
@@ -174,15 +170,10 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                         ring,
                         otherStat,
                     }).map(([key, value]) => (
-                        <section key={key}>
-                            <h2 className="text-xl font-bold mb-2">{key}</h2>
-                            <pre className="text-sm bg-muted p-2 rounded overflow-x-auto">
-                                {JSON.stringify(value, null, 2)}
-                            </pre>
-                        </section>
+                        <JsonCard key={key} title={key} data={value} />
                     ))}
 
-                    {/* 꾸미기 / 기타 - JSON 프리뷰 */}
+                    {/* 꾸미기 / 기타 */}
                     {Object.entries({
                         beauty,
                         android,
@@ -190,12 +181,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                         propensity,
                         ability,
                     }).map(([key, value]) => (
-                        <section key={key}>
-                            <h2 className="text-xl font-bold mb-2">{key}</h2>
-                            <pre className="text-sm bg-muted p-2 rounded overflow-x-auto">
-                                {JSON.stringify(value, null, 2)}
-                            </pre>
-                        </section>
+                        <JsonCard key={key} title={key} data={value} />
                     ))}
                 </div>
             </ScrollArea>

--- a/src/components/character/card/JsonCard.tsx
+++ b/src/components/character/card/JsonCard.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface JsonCardProps {
+  title: string;
+  data: unknown;
+}
+
+export function JsonCard({ title, data }: JsonCardProps) {
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <pre className="text-sm bg-muted p-2 rounded overflow-x-auto">
+          {data ? JSON.stringify(data, null, 2) : "-"}
+        </pre>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- render equipment, advanced, and decoration data using card components
- add reusable JsonCard component for JSON-style content

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c377fabb348324908e5b2e154d37d4