### PR TITLE
feat: add item equipment card

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -8,6 +8,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { StatCard } from "@/components/character/card/StatCard";
 import { PopularityCard } from "@/components/character/card/PopularityCard";
 import { HyperStatCard } from "@/components/character/card/HyperStatCard";
+import { ItemEquipCard } from "@/components/character/card/ItemEquipCard";
 import { characterDetailStore } from "@/store/characterDetailStore";
 import { toast } from "sonner";
 
@@ -148,9 +149,23 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                     {popularity && <PopularityCard popularity={popularity.popularity}/>}
                     {hyper && <HyperStatCard hyper={hyper}/>}
 
-                    {/* 장비 / 스킬 - 카드 UI 미구현으로 JSON 프리뷰 */}
+                    {/* 장비 */}
+                    {itemEquip?.item_equipment && (
+                        <section className="w-full">
+                            <h2 className="text-xl font-bold mb-2">itemEquip</h2>
+                            <div className="space-y-2">
+                                {itemEquip.item_equipment.map((equip) => (
+                                    <ItemEquipCard
+                                        key={`${equip.item_equipment_part}-${equip.item_equipment_slot}`}
+                                        item={equip}
+                                    />
+                                ))}
+                            </div>
+                        </section>
+                    )}
+
+                    {/* 스킬 등 - JSON 프리뷰 */}
                     {Object.entries({
-                        itemEquip,
                         cashEquip,
                         symbolEquip,
                         setEffect,

--- a/src/components/character/card/ItemEquipCard.tsx
+++ b/src/components/character/card/ItemEquipCard.tsx
@@ -1,0 +1,50 @@
+import Image from "next/image";
+import { Card, CardContent } from "@/components/ui/card";
+import { IItemEquipment } from "@/interface/ICharacter";
+
+export const ItemEquipCard = ({ item }: { item: IItemEquipment }) => {
+    return (
+        <Card className="flex items-center p-2 gap-3 hover:shadow-lg transition">
+            {/* 아이콘 */}
+            <div className="relative w-12 h-12 flex-shrink-0">
+                <Image
+                    src={item.item_icon}
+                    alt={item.item_name}
+                    fill
+                    className="object-contain"
+                />
+            </div>
+
+            {/* 정보 */}
+            <CardContent className="p-0 flex-1">
+                {/* 이름 + 강화정보 */}
+                <div className="flex justify-between items-center">
+                    <h3 className="font-bold text-sm">{item.item_name}</h3>
+                    {item.starforce && (
+                        <span className="text-yellow-500 text-xs">★{item.starforce}</span>
+                    )}
+                </div>
+
+                {/* 주요 옵션 */}
+                <div className="text-xs text-muted-foreground space-x-2">
+                    {item.item_total_option?.dex && (
+                        <span>DEX {item.item_total_option.dex}</span>
+                    )}
+                    {item.item_total_option?.attack_power && (
+                        <span>공 {item.item_total_option.attack_power}</span>
+                    )}
+                    {item.item_total_option?.magic_power && (
+                        <span>마 {item.item_total_option.magic_power}</span>
+                    )}
+                </div>
+
+                {/* 잠재옵션 */}
+                <div className="text-xs mt-1">
+                    {item.potential_option_1 && <p>{item.potential_option_1}</p>}
+                    {item.potential_option_2 && <p>{item.potential_option_2}</p>}
+                    {item.potential_option_3 && <p>{item.potential_option_3}</p>}
+                </div>
+            </CardContent>
+        </Card>
+    );
+};

--- a/src/interface/ICharacter.ts
+++ b/src/interface/ICharacter.ts
@@ -48,11 +48,25 @@ export interface IItemEquipment {
     item_equipment_slot: string
     item_name: string
     item_icon: string
+    potential_option_grade?: string | null
+    starforce?: string
+    item_total_option?: {
+        str?: string
+        dex?: string
+        int?: string
+        luk?: string
+        attack_power?: string
+        magic_power?: string
+        boss_damage?: string
+        ignore_monster_armor?: string
+    }
+    potential_option_1?: string | null
+    potential_option_2?: string | null
+    potential_option_3?: string | null
     item_description: string
     item_shape_name: string
     item_shape_icon: string
     item_gender: string
-    // ... (추가 옵션들 필요 시 확장)
 }
 
 export interface ICharacterCashItemEquipment {


### PR DESCRIPTION
## Summary
- display character item equipment using dedicated ItemEquipCard
- extend item equipment interface with detailed option fields

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c37bffda34832497b5b0fa8055ce5a