### PR TITLE
refactor home panels

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -4,14 +4,13 @@ import { unstable_ViewTransition as ViewTransition, useEffect, useState } from "
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
-import CharacterCard from "@/components/character/CharacterCard";
-import CharacterCardSkeleton from "@/components/character/CharacterCardSkeleton";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { addFavorite, getFavorites, removeFavorite } from "@/fetchs/favorite.fetch";
 import { findCharacterBasic } from "@/fetchs/character.fetch";
 import { ICharacterSummary } from "@/interface/ICharacterSummary";
+import FavoriteList from "@/components/home/FavoriteList";
+import CharacterInfo from "@/components/home/CharacterInfo";
 
 const Home = () => {
     const [user, setUser] = useState<{ id: string; email?: string } | null>(null);
@@ -94,62 +93,13 @@ const Home = () => {
     return (
         <ViewTransition enter="fade" exit="fade">
             <div className="flex h-full">
-                {/* 좌측 영역: 항상 표시 */}
-                <ScrollArea className="w-full md:w-1/3 border-r p-4">
-                    <div className="space-y-4">
-                        {loading
-                            ? Array.from({ length: 3 }).map((_, i) => (
-                                <CharacterCardSkeleton key={i}/>
-                            ))
-                            : favorites.map((c) => (
-                                <CharacterCard
-                                    key={c.ocid}
-                                    character={c}
-                                    isFavorite
-                                    onToggleFavorite={() => toggleFavorite(c.ocid)}
-                                    onSelect={() => handleSelect(c.ocid)}
-                                />
-                            ))}
-                    </div>
-                </ScrollArea>
-
-                {/* 우측 영역: md 이상에서만 표시 */}
-                <ScrollArea className="hidden md:flex flex-1">
-                    {selectedCharacter ? (
-                        <div className="p-4 space-y-4 max-w-2xl mx-auto">
-                            {selectedCharacter.image && (
-                                <div className="relative w-64 h-64 mx-auto">
-                                    <Image
-                                        src={selectedCharacter.image}
-                                        alt={selectedCharacter.character_name}
-                                        fill
-                                        className="object-contain"
-                                        style={{
-                                            viewTransitionName: `character-image-${selectedCharacter.ocid}`,
-                                        }}
-                                        sizes="256px"
-                                    />
-                                </div>
-                            )}
-                            <h2 className="text-2xl font-bold text-center">
-                                {selectedCharacter.character_name}
-                            </h2>
-                            <p className="text-center text-muted-foreground">
-                                {selectedCharacter.character_class}
-                            </p>
-                            <p className="text-center font-bold text-red-500">
-                                Lv. {selectedCharacter.character_level}
-                            </p>
-                            <div className="flex justify-center">
-                                <Button onClick={handleDetail}>Detail</Button>
-                            </div>
-                        </div>
-                    ) : (
-                        <div className="flex justify-center items-center w-full h-page animate-pulse ">
-                            Please choose your character
-                        </div>
-                    )}
-                </ScrollArea>
+                <FavoriteList
+                    favorites={favorites}
+                    loading={loading}
+                    onSelect={handleSelect}
+                    onToggleFavorite={toggleFavorite}
+                />
+                <CharacterInfo ocid={selected} />
 
                 {/* 모바일 다이얼로그 */}
                 <Dialog open={open} onOpenChange={setOpen}>

--- a/src/components/home/CharacterInfo.tsx
+++ b/src/components/home/CharacterInfo.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
+import ItemEquipments from "@/components/character/item/ItemEquipments";
+import { findCharacterBasic, findCharacterItemEquipment } from "@/fetchs/character.fetch";
+import { IItemEquipment } from "@/interface/ICharacter";
+
+interface IBasicInfo {
+    character_name: string;
+    character_level: number;
+    character_class: string;
+    character_image?: string;
+}
+
+interface ICharacterInfoProps {
+    ocid: string | null;
+}
+
+const CharacterInfo = ({ ocid }: ICharacterInfoProps) => {
+    const [basic, setBasic] = useState<IBasicInfo | null>(null);
+    const [items, setItems] = useState<IItemEquipment[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (!ocid) return;
+        const load = async () => {
+            setLoading(true);
+            try {
+                const [basicRes, itemRes] = await Promise.all([
+                    findCharacterBasic(ocid),
+                    findCharacterItemEquipment(ocid),
+                ]);
+                setBasic(basicRes as IBasicInfo);
+                setItems(itemRes.item_equipment);
+            } finally {
+                setLoading(false);
+            }
+        };
+        load();
+    }, [ocid]);
+
+    return (
+        <ScrollArea className="hidden md:flex flex-1">
+            {!ocid ? (
+                <div className="flex justify-center items-center w-full h-page animate-pulse">
+                    Please choose your character
+                </div>
+            ) : loading || !basic ? (
+                <div className="flex justify-center items-center w-full h-page">
+                    <Spinner />
+                </div>
+            ) : (
+                <div className="p-4 space-y-4 max-w-2xl mx-auto">
+                    {basic.character_image && (
+                        <div className="relative w-64 h-64 mx-auto">
+                            <Image
+                                src={basic.character_image}
+                                alt={basic.character_name}
+                                fill
+                                className="object-contain"
+                                sizes="256px"
+                            />
+                        </div>
+                    )}
+                    <h2 className="text-2xl font-bold text-center">{basic.character_name}</h2>
+                    <p className="text-center text-muted-foreground">{basic.character_class}</p>
+                    <p className="text-center font-bold text-red-500">Lv. {basic.character_level}</p>
+                    {items.length > 0 && <ItemEquipments items={items} />}
+                </div>
+            )}
+        </ScrollArea>
+    );
+};
+
+export default CharacterInfo;

--- a/src/components/home/FavoriteList.tsx
+++ b/src/components/home/FavoriteList.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import CharacterCard from "@/components/character/CharacterCard";
+import CharacterCardSkeleton from "@/components/character/CharacterCardSkeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ICharacterSummary } from "@/interface/ICharacterSummary";
+
+interface IFavoriteListProps {
+    favorites: ICharacterSummary[];
+    loading: boolean;
+    onSelect: (ocid: string) => void;
+    onToggleFavorite: (ocid: string) => void;
+}
+
+const FavoriteList = ({ favorites, loading, onSelect, onToggleFavorite }: IFavoriteListProps) => {
+    return (
+        <ScrollArea className="w-full md:w-1/3 md:border-r p-4">
+            <div className="space-y-4">
+                {loading
+                    ? Array.from({ length: 3 }).map((_, i) => <CharacterCardSkeleton key={i} />)
+                    : favorites.map((c) => (
+                        <CharacterCard
+                            key={c.ocid}
+                            character={c}
+                            isFavorite
+                            onToggleFavorite={() => onToggleFavorite(c.ocid)}
+                            onSelect={() => onSelect(c.ocid)}
+                        />
+                    ))}
+            </div>
+        </ScrollArea>
+    );
+};
+
+export default FavoriteList;


### PR DESCRIPTION
## Summary
- split home page into left list and right detail components
- fetch and display character equipment in right panel
- hide list border on small screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3a6e188508324a58a433257786158