### PR TITLE
refactor: introduce generic character response

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -37,11 +37,11 @@ const Home = () => {
                     const data = await findCharacterBasic(ocid);
                     return {
                         ocid,
-                        character_name: data.character_name,
-                        world_name: data.world_name,
-                        character_class: data.character_class,
-                        character_level: data.character_level,
-                        image: data.character_image,
+                        character_name: data.data.character_name,
+                        world_name: data.data.world_name,
+                        character_class: data.data.character_class,
+                        character_level: data.data.character_level,
+                        image: data.data.character_image,
                     } as ICharacterSummary;
                 })
             );
@@ -65,11 +65,11 @@ const Home = () => {
                 ...favorites,
                 {
                     ocid,
-                    character_name: data.character_name,
-                    world_name: data.world_name,
-                    character_class: data.character_class,
-                    character_level: data.character_level,
-                    image: data.character_image,
+                    character_name: data.data.character_name,
+                    world_name: data.data.world_name,
+                    character_class: data.data.character_class,
+                    character_level: data.data.character_level,
+                    image: data.data.character_image,
                 },
             ]);
         }

--- a/src/app/api/character/[endpoint]/route.ts
+++ b/src/app/api/character/[endpoint]/route.ts
@@ -23,7 +23,7 @@ export const GET = async (
                     headers: { "x-nxopen-api-key": apiKey },
                 }
             );
-            return Success("캐릭터 정보 조회 성공", 200, res.data);
+            return Success("캐릭터 정보 조회 성공", 200, { data: res.data });
         } catch (err: unknown) {
             if (err instanceof AxiosError) {
                 const message =

--- a/src/app/api/character/list/route.ts
+++ b/src/app/api/character/list/route.ts
@@ -28,7 +28,9 @@ export const GET = async (req: Request) => {
                 (account) => account.character_list
             );
 
-            return Success("캐릭터 목록 조회 성공", 200, { characters });
+            return Success("캐릭터 목록 조회 성공", 200, {
+                data: { characters },
+            });
         } catch (err: unknown) {
             if (err instanceof AxiosError) {
                 const message = err.response?.data?.error?.message ?? err.message;

--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -40,14 +40,14 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                     findCharacterPopularity(ocid),
                     findCharacterHyperStat(ocid),
                 ]);
-                setBasic(basicRes)
-                setStat(stat)
-                setPopularity(popularity)
-                setHyper(hyper)
+                setBasic(basicRes.data)
+                setStat(stat.data)
+                setPopularity(popularity.data)
+                setHyper(hyper.data)
 
                 // 장비/스킬
                 const grades = ["0", "1", "2", "3", "4", "5", "6", "hyperpassive", "hyperactive"]
-                const [itemEquip, cashEquip, symbolEquip, setEffect, skill, linkSkill] =
+                const [itemEquipRes, cashEquipRes, symbolEquipRes, setEffectRes, skillRes, linkSkillRes] =
                     await Promise.all([
                         findCharacterItemEquipment(ocid),
                         findCharacterCashItemEquipment(ocid),
@@ -56,15 +56,15 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                         Promise.all(grades.map((g) => findCharacterSkill(ocid, g))),
                         findCharacterLinkSkill(ocid),
                     ]);
-                setItemEquip(itemEquip)
-                setCashEquip(cashEquip)
-                setSymbolEquip(symbolEquip)
-                setSetEffect(setEffect)
-                setSkill(skill)
-                setLinkSkill(linkSkill)
+                setItemEquip(itemEquipRes.data)
+                setCashEquip(cashEquipRes.data)
+                setSymbolEquip(symbolEquipRes.data)
+                setSetEffect(setEffectRes.data)
+                setSkill(skillRes.map((s) => s.data))
+                setLinkSkill(linkSkillRes.data)
 
                 // 심화
-                const [hexaMatrix, hexaStat, vMatrix, dojang, ring, otherStat] =
+                const [hexaMatrixRes, hexaStatRes, vMatrixRes, dojangRes, ringRes, otherStatRes] =
                     await Promise.all([
                         findCharacterHexaMatrix(ocid),
                         findCharacterHexaMatrixStat(ocid),
@@ -73,26 +73,26 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                         findCharacterRingExchange(ocid),
                         findCharacterOtherStat(ocid),
                     ]);
-                setHexaMatrix(hexaMatrix)
-                setHexaStat(hexaStat)
-                setVMatrix(vMatrix)
-                setDojang(dojang)
-                setRing(ring)
-                setOtherStat(otherStat)
+                setHexaMatrix(hexaMatrixRes.data)
+                setHexaStat(hexaStatRes.data)
+                setVMatrix(vMatrixRes.data)
+                setDojang(dojangRes.data)
+                setRing(ringRes.data)
+                setOtherStat(otherStatRes.data)
 
                 // 꾸미기/기타
-                const [beauty, android, pet, propensity, ability] = await Promise.all([
+                const [beautyRes, androidRes, petRes, propensityRes, abilityRes] = await Promise.all([
                     findCharacterBeautyEquipment(ocid),
                     findCharacterAndroidEquipment(ocid),
                     findCharacterPetEquipment(ocid),
                     findCharacterPropensity(ocid),
                     findCharacterAbility(ocid),
                 ]);
-                setBeauty(beauty)
-                setAndroid(android)
-                setPet(pet)
-                setPropensity(propensity)
-                setAbility(ability)
+                setBeauty(beautyRes.data)
+                setAndroid(androidRes.data)
+                setPet(petRes.data)
+                setPropensity(propensityRes.data)
+                setAbility(abilityRes.data)
             } catch (e) {
                 console.error(e)
                 toast.error('캐릭터 정보 로딩 실패');

--- a/src/components/character/detail/HyperStat.tsx
+++ b/src/components/character/detail/HyperStat.tsx
@@ -2,7 +2,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ICharacterHyperStat } from "@/interface/character/ICharacter";
 
-export function HyperStat({ hyper }: { hyper: ICharacterHyperStat }) {
+export const HyperStat = ({ hyper }: { hyper: ICharacterHyperStat }) => {
     const presets = [
         { key: "1", label: "프리셋 1", stats: hyper.hyper_stat_preset_1 },
         { key: "2", label: "프리셋 2", stats: hyper.hyper_stat_preset_2 },
@@ -43,3 +43,4 @@ export function HyperStat({ hyper }: { hyper: ICharacterHyperStat }) {
         </Card>
     )
 }
+

--- a/src/components/character/detail/Popularity.tsx
+++ b/src/components/character/detail/Popularity.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-export function Popularity({ popularity }: { popularity: number }) {
+export const Popularity = ({ popularity }: { popularity: number }) => {
     return (
         <Card className="w-full">
             <CardHeader>
@@ -12,3 +12,4 @@ export function Popularity({ popularity }: { popularity: number }) {
         </Card>
     )
 }
+

--- a/src/components/character/detail/Stat.tsx
+++ b/src/components/character/detail/Stat.tsx
@@ -3,7 +3,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Badge } from "@/components/ui/badge"
 import { ICharacterStat } from "@/interface/character/ICharacter"
 
-export function Stat({ stat }: { stat: ICharacterStat }) {
+export const Stat = ({ stat }: { stat: ICharacterStat }) => {
     const highlights = ["전투력", "보스 몬스터 데미지", "크리티컬 확률", "크리티컬 데미지"]
 
     return (
@@ -38,3 +38,4 @@ export function Stat({ stat }: { stat: ICharacterStat }) {
         </Card>
     )
 }
+

--- a/src/components/home/CharacterInfo.tsx
+++ b/src/components/home/CharacterInfo.tsx
@@ -6,8 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import ItemEquipments from "@/components/character/item/ItemEquipments";
 import { findCharacterBasic, findCharacterItemEquipment } from "@/fetchs/character.fetch";
-import { IItemEquipment } from "@/interface/character/ICharacter";
-import { ICharacterResponse } from "@/interface/character/ICharacterResponse";
+import { IItemEquipment, ICharacterBasic } from "@/interface/character/ICharacter";
 import WorldIcon from "@/components/common/WorldIcon";
 import { Button } from "@/components/ui/button";
 
@@ -17,7 +16,7 @@ interface ICharacterInfoProps {
 }
 
 const CharacterInfo = ({ ocid, goToDetailPage }: ICharacterInfoProps) => {
-    const [basic, setBasic] = useState<ICharacterResponse | null>(null);
+    const [basic, setBasic] = useState<ICharacterBasic | null>(null);
     const [items, setItems] = useState<IItemEquipment[]>([]);
     const [loading, setLoading] = useState(false);
 
@@ -30,8 +29,8 @@ const CharacterInfo = ({ ocid, goToDetailPage }: ICharacterInfoProps) => {
                     findCharacterBasic(ocid),
                     findCharacterItemEquipment(ocid),
                 ]);
-                setBasic(basicRes as ICharacterResponse);
-                setItems(itemRes.item_equipment);
+                setBasic(basicRes.data);
+                setItems(itemRes.data.item_equipment);
             } finally {
                 setLoading(false);
             }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -25,13 +25,13 @@ const badgeVariants = cva(
   }
 )
 
-function Badge({
+const Badge = ({
   className,
   variant,
   asChild = false,
   ...props
 }: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) => {
   const Comp = asChild ? Slot : "span"
 
   return (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -6,34 +6,34 @@ import { XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Dialog({
+const Dialog = ({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+}: React.ComponentProps<typeof DialogPrimitive.Root>) => {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
-function DialogTrigger({
+const DialogTrigger = ({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) => {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
-function DialogPortal({
+const DialogPortal = ({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) => {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
-function DialogClose({
+const DialogClose = ({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+}: React.ComponentProps<typeof DialogPrimitive.Close>) => {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
-function DialogOverlay({
+const DialogOverlay = ({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) => {
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
@@ -46,14 +46,14 @@ function DialogOverlay({
   )
 }
 
-function DialogContent({
+const DialogContent = ({
   className,
   children,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
-}) {
+}) => {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -80,7 +80,7 @@ function DialogContent({
   )
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+const DialogHeader = ({ className, ...props }: React.ComponentProps<"div">) => {
   return (
     <div
       data-slot="dialog-header"
@@ -90,7 +90,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+const DialogFooter = ({ className, ...props }: React.ComponentProps<"div">) => {
   return (
     <div
       data-slot="dialog-footer"
@@ -103,10 +103,10 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function DialogTitle({
+const DialogTitle = ({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+}: React.ComponentProps<typeof DialogPrimitive.Title>) => {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
@@ -116,10 +116,10 @@ function DialogTitle({
   )
 }
 
-function DialogDescription({
+const DialogDescription = ({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+}: React.ComponentProps<typeof DialogPrimitive.Description>) => {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -5,24 +5,24 @@ import * as PopoverPrimitive from "@radix-ui/react-popover"
 
 import { cn } from "@/lib/utils"
 
-function Popover({
+const Popover = ({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) => {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
 }
 
-function PopoverTrigger({
+const PopoverTrigger = ({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) => {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
-function PopoverContent({
+const PopoverContent = ({
   className,
   align = "center",
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) => {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
@@ -39,9 +39,9 @@ function PopoverContent({
   )
 }
 
-function PopoverAnchor({
+const PopoverAnchor = ({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) => {
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
 }
 

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -5,11 +5,11 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
-function ScrollArea({
+const ScrollArea = ({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) => {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -28,11 +28,11 @@ function ScrollArea({
   )
 }
 
-function ScrollBar({
+const ScrollBar = ({
   className,
   orientation = "vertical",
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) => {
   return (
     <ScrollAreaPrimitive.ScrollAreaScrollbar
       data-slot="scroll-area-scrollbar"

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+const Table = ({ className, ...props }: React.ComponentProps<"table">) => {
   return (
     <div
       data-slot="table-container"
@@ -19,7 +19,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   )
 }
 
-function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+const TableHeader = ({ className, ...props }: React.ComponentProps<"thead">) => {
   return (
     <thead
       data-slot="table-header"
@@ -29,7 +29,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   )
 }
 
-function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+const TableBody = ({ className, ...props }: React.ComponentProps<"tbody">) => {
   return (
     <tbody
       data-slot="table-body"
@@ -39,7 +39,7 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   )
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+const TableFooter = ({ className, ...props }: React.ComponentProps<"tfoot">) => {
   return (
     <tfoot
       data-slot="table-footer"
@@ -52,7 +52,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   )
 }
 
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+const TableRow = ({ className, ...props }: React.ComponentProps<"tr">) => {
   return (
     <tr
       data-slot="table-row"
@@ -65,7 +65,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
   )
 }
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+const TableHead = ({ className, ...props }: React.ComponentProps<"th">) => {
   return (
     <th
       data-slot="table-head"
@@ -78,7 +78,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
   )
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+const TableCell = ({ className, ...props }: React.ComponentProps<"td">) => {
   return (
     <td
       data-slot="table-cell"
@@ -91,10 +91,10 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   )
 }
 
-function TableCaption({
+const TableCaption = ({
   className,
   ...props
-}: React.ComponentProps<"caption">) {
+}: React.ComponentProps<"caption">) => {
   return (
     <caption
       data-slot="table-caption"

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -5,10 +5,10 @@ import * as TabsPrimitive from "@radix-ui/react-tabs"
 
 import { cn } from "@/lib/utils"
 
-function Tabs({
+const Tabs = ({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+}: React.ComponentProps<typeof TabsPrimitive.Root>) => {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
@@ -18,10 +18,10 @@ function Tabs({
   )
 }
 
-function TabsList({
+const TabsList = ({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+}: React.ComponentProps<typeof TabsPrimitive.List>) => {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
@@ -34,10 +34,10 @@ function TabsList({
   )
 }
 
-function TabsTrigger({
+const TabsTrigger = ({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) => {
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
@@ -50,10 +50,10 @@ function TabsTrigger({
   )
 }
 
-function TabsContent({
+const TabsContent = ({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+}: React.ComponentProps<typeof TabsPrimitive.Content>) => {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"

--- a/src/fetchs/character.fetch.ts
+++ b/src/fetchs/character.fetch.ts
@@ -1,5 +1,30 @@
 import axios from "axios";
 import { userStore } from "@/store/userStore";
+import { CharacterResponse } from "@/interface/CharacterResponse";
+import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import {
+    ICharacterAbility,
+    ICharacterAndroidEquipment,
+    ICharacterBeautyEquipment,
+    ICharacterBasic,
+    ICharacterCashItemEquipment,
+    ICharacterDojang,
+    ICharacterHexaMatrix,
+    ICharacterHexaMatrixStat,
+    ICharacterHyperStat,
+    ICharacterItemEquipment,
+    ICharacterLinkSkill,
+    ICharacterOtherStat,
+    ICharacterPetEquipment,
+    ICharacterPopularity,
+    ICharacterPropensity,
+    ICharacterSetEffect,
+    ICharacterSkill,
+    ICharacterStat,
+    ICharacterSymbolEquipment,
+    ICharacterVMatrix,
+    IRingExchangeSkillEquipment,
+} from "@/interface/character/ICharacter";
 
 const delay = (ms: number) =>
     new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -8,23 +33,28 @@ let requestQueue: Promise<unknown> = Promise.resolve();
 
 export const findCharacterList = async () => {
     const apiKey = userStore.getState().user.apiKey;
-    const response = await axios.get(`/api/character/list`, {
-        headers: { "x-nxopen-api-key": apiKey ?? "" },
-    });
+    const response = await axios.get<CharacterResponse<{ characters: ICharacterSummary[] }>>(
+        `/api/character/list`,
+        {
+            headers: { "x-nxopen-api-key": apiKey ?? "" },
+        }
+    );
     return response.data;
 };
 
-const callCharacterApi = async (
+const callCharacterApi = async <T>(
     endpoint: string,
     params: Record<string, string | number | undefined> = {}
-) => {
+): Promise<CharacterResponse<T>> => {
     const apiKey = userStore.getState().user.apiKey;
 
     const task = async () => {
         await delay(200);
-        const response = await axios.get(`/api/character/${endpoint}`, {
+        const response = await axios.get<CharacterResponse<T>>(`/api/character/${endpoint}`, {
             headers: { "x-nxopen-api-key": apiKey ?? "" },
-            params: Object.fromEntries(Object.entries(params).filter(([_, v]) => v !== undefined)),
+            params: Object.fromEntries(
+                Object.entries(params).filter(([_, v]) => v !== undefined)
+            ),
         });
         return response.data;
     };
@@ -36,69 +66,69 @@ const callCharacterApi = async (
 
 /* ---------------- 기본 API ---------------- */
 export const findCharacterBasic = (ocid: string, date?: string) =>
-    callCharacterApi("basic", { ocid, date });
+    callCharacterApi<ICharacterBasic>("basic", { ocid, date });
 
 export const findCharacterPopularity = (ocid: string, date?: string) =>
-    callCharacterApi("popularity", { ocid, date });
+    callCharacterApi<ICharacterPopularity>("popularity", { ocid, date });
 
 export const findCharacterStat = (ocid: string, date?: string) =>
-    callCharacterApi("stat", { ocid, date });
+    callCharacterApi<ICharacterStat>("stat", { ocid, date });
 
 export const findCharacterHyperStat = (ocid: string, date?: string) =>
-    callCharacterApi("hyper-stat", { ocid, date });
+    callCharacterApi<ICharacterHyperStat>("hyper-stat", { ocid, date });
 
 export const findCharacterPropensity = (ocid: string, date?: string) =>
-    callCharacterApi("propensity", { ocid, date });
+    callCharacterApi<ICharacterPropensity>("propensity", { ocid, date });
 
 export const findCharacterAbility = (ocid: string, date?: string) =>
-    callCharacterApi("ability", { ocid, date });
+    callCharacterApi<ICharacterAbility>("ability", { ocid, date });
 
 export const findCharacterItemEquipment = (ocid: string, date?: string) =>
-    callCharacterApi("item-equipment", { ocid, date });
+    callCharacterApi<ICharacterItemEquipment>("item-equipment", { ocid, date });
 
 export const findCharacterCashItemEquipment = (ocid: string, date?: string) =>
-    callCharacterApi("cashitem-equipment", { ocid, date });
+    callCharacterApi<ICharacterCashItemEquipment>("cashitem-equipment", { ocid, date });
 
 export const findCharacterSymbolEquipment = (ocid: string, date?: string) =>
-    callCharacterApi("symbol-equipment", { ocid, date });
+    callCharacterApi<ICharacterSymbolEquipment>("symbol-equipment", { ocid, date });
 
 export const findCharacterSetEffect = (ocid: string, date?: string) =>
-    callCharacterApi("set-effect", { ocid, date });
+    callCharacterApi<ICharacterSetEffect>("set-effect", { ocid, date });
 
 export const findCharacterBeautyEquipment = (ocid: string, date?: string) =>
-    callCharacterApi("beauty-equipment", { ocid, date });
+    callCharacterApi<ICharacterBeautyEquipment>("beauty-equipment", { ocid, date });
 
 export const findCharacterAndroidEquipment = (ocid: string, date?: string) =>
-    callCharacterApi("android-equipment", { ocid, date });
+    callCharacterApi<ICharacterAndroidEquipment>("android-equipment", { ocid, date });
 
 export const findCharacterPetEquipment = (ocid: string, date?: string) =>
-    callCharacterApi("pet-equipment", { ocid, date });
+    callCharacterApi<ICharacterPetEquipment>("pet-equipment", { ocid, date });
 
 /* ---------------- 스킬 API ---------------- */
 // character_skill_grade 필수, date는 옵션
 export const findCharacterSkill = (ocid: string, grade: string, date?: string) =>
-    callCharacterApi("skill", { ocid, character_skill_grade: grade, date, });
+    callCharacterApi<ICharacterSkill>("skill", { ocid, character_skill_grade: grade, date });
 
 export const findCharacterLinkSkill = (ocid: string, date?: string) =>
-    callCharacterApi("link-skill", { ocid, date });
+    callCharacterApi<ICharacterLinkSkill>("link-skill", { ocid, date });
 
 export const findCharacterVMatrix = (ocid: string, date?: string) =>
-    callCharacterApi("vmatrix", { ocid, date });
+    callCharacterApi<ICharacterVMatrix>("vmatrix", { ocid, date });
 
 export const findCharacterHexaMatrix = (ocid: string, date?: string) =>
-    callCharacterApi("hexamatrix", { ocid, date });
+    callCharacterApi<ICharacterHexaMatrix>("hexamatrix", { ocid, date });
 
 export const findCharacterHexaMatrixStat = (ocid: string, date?: string) =>
-    callCharacterApi("hexamatrix-stat", { ocid, date });
+    callCharacterApi<ICharacterHexaMatrixStat>("hexamatrix-stat", { ocid, date });
 
 export const findCharacterDojang = (ocid: string, date?: string) =>
-    callCharacterApi("dojang", { ocid, date });
+    callCharacterApi<ICharacterDojang>("dojang", { ocid, date });
 
 export const findCharacterOtherStat = (ocid: string, date?: string) =>
-    callCharacterApi("other-stat", { ocid, date });
+    callCharacterApi<ICharacterOtherStat>("other-stat", { ocid, date });
 
 export const findCharacterRingExchange = (ocid: string, date?: string) =>
-    callCharacterApi("ring-exchange-skill-equipment", { ocid, date });
+    callCharacterApi<IRingExchangeSkillEquipment>("ring-exchange-skill-equipment", { ocid, date });
 
 export const findCharacterId = (character_name: string) =>
-    callCharacterApi("id", { character_name });
+    callCharacterApi<{ ocid: string }>("id", { character_name });

--- a/src/interface/CharacterResponse.ts
+++ b/src/interface/CharacterResponse.ts
@@ -1,0 +1,5 @@
+export interface CharacterResponse<T> {
+    message: string;
+    status: number;
+    data: T;
+}

--- a/src/interface/character/ICharacter.ts
+++ b/src/interface/character/ICharacter.ts
@@ -1,4 +1,22 @@
 /* -------------------- 기본 정보 -------------------- */
+export interface ICharacterBasic {
+    date: string;
+    character_name: string;
+    world_name: string;
+    character_gender: string;
+    character_class: string;
+    character_class_level: string;
+    character_level: number;
+    character_exp: number;
+    character_exp_rate: string;
+    character_guild_name: string;
+    character_image: string;
+    character_date_create: string;
+    access_flag: string;
+    liberation_quest_clear_flag: string;
+    liberation_quest_clear: string;
+}
+
 export interface ICharacterStat {
     date: string
     character_class: string

--- a/src/interface/character/ICharacterListResponse.ts
+++ b/src/interface/character/ICharacterListResponse.ts
@@ -1,7 +1,0 @@
-import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
-
-export interface ICharacterListResponse {
-    message: string;
-    status: number;
-    characters: ICharacterSummary[];
-}

--- a/src/interface/character/ICharacterResponse.ts
+++ b/src/interface/character/ICharacterResponse.ts
@@ -1,8 +1,0 @@
-export interface ICharacterResponse {
-    character_class: string;
-    character_name: string
-    world_name: string
-    character_level: number
-    character_job: string
-    character_image: string
-}

--- a/src/store/characterDetailStore.ts
+++ b/src/store/characterDetailStore.ts
@@ -1,11 +1,10 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { ICharacterResponse } from "@/interface/character/ICharacterResponse";
-import { ICharacterAbility, ICharacterAndroidEquipment, ICharacterBeautyEquipment, ICharacterCashItemEquipment, ICharacterDojang, ICharacterHexaMatrix, ICharacterHexaMatrixStat, ICharacterHyperStat, ICharacterItemEquipment, ICharacterLinkSkill, ICharacterOtherStat, ICharacterPetEquipment, ICharacterPopularity, ICharacterPropensity, ICharacterSetEffect, ICharacterSkill, ICharacterStat, ICharacterSymbolEquipment, ICharacterVMatrix, IRingExchangeSkillEquipment, } from "@/interface/character/ICharacter";
+import { ICharacterAbility, ICharacterAndroidEquipment, ICharacterBeautyEquipment, ICharacterCashItemEquipment, ICharacterDojang, ICharacterHexaMatrix, ICharacterHexaMatrixStat, ICharacterHyperStat, ICharacterItemEquipment, ICharacterLinkSkill, ICharacterOtherStat, ICharacterPetEquipment, ICharacterPopularity, ICharacterPropensity, ICharacterSetEffect, ICharacterSkill, ICharacterStat, ICharacterSymbolEquipment, ICharacterVMatrix, IRingExchangeSkillEquipment, ICharacterBasic, } from "@/interface/character/ICharacter";
 
 type CharacterDetailSlice = {
     // 기본 정보
-    basic: Pick<ICharacterResponse, 'character_image' | 'character_name'> | null
+    basic: Pick<ICharacterBasic, 'character_image' | 'character_name'> | null
     stat: ICharacterStat | null
     popularity: ICharacterPopularity | null
     hyper: ICharacterHyperStat | null

--- a/src/store/characterListStore.ts
+++ b/src/store/characterListStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
 import { findCharacterBasic, findCharacterList } from "@/fetchs/character.fetch";
-import { ICharacterListResponse } from "@/interface/character/ICharacterListResponse";
+import { CharacterResponse } from "@/interface/CharacterResponse";
 
 type CharacterListSlice = {
     characters: ICharacterSummary[];
@@ -16,8 +16,8 @@ export const characterListStore = create<CharacterListSlice>()(persist((set) => 
         fetchCharacters: async () => {
             set({ loading: true });
             try {
-                const res: ICharacterListResponse = await findCharacterList();
-                const basicList = (res.characters ?? []).map((c) => ({
+                const res: CharacterResponse<{ characters: ICharacterSummary[] }> = await findCharacterList();
+                const basicList = (res.data.characters ?? []).map((c) => ({
                     ocid: c.ocid,
                     character_name: c.character_name,
                     world_name: c.world_name,
@@ -32,7 +32,7 @@ export const characterListStore = create<CharacterListSlice>()(persist((set) => 
                         const data = await findCharacterBasic(char.ocid);
                         set((state) => ({
                             characters: state.characters.map((c) =>
-                                c.ocid === char.ocid ? { ...c, image: data.character_image } : c
+                                c.ocid === char.ocid ? { ...c, image: data.data.character_image } : c
                             ),
                         }));
                     }


### PR DESCRIPTION
## Summary
- add reusable `CharacterResponse<T>` interface for all character API replies
- refactor API routes, fetch utilities, stores and components to use `CharacterResponse`
- remove legacy response interfaces and add `ICharacterBasic`
- declare all functions as `const` arrow functions for consistency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3ba1fd7408324bc1f2647469dc4cb