### PR TITLE
feat: allow optional Nexon API key

### DIFF
--- a/src/app/(auth)/sign_up/page.tsx
+++ b/src/app/(auth)/sign_up/page.tsx
@@ -23,7 +23,7 @@ const SignUpPage = () => {
         const { data, error } = await supabase.auth.signUp({
             email: form.email,
             password: form.password,
-            options: { data: { nexon_api_key: form.apiKey } },
+            options: { data: form.apiKey ? { nexon_api_key: form.apiKey } : {} },
         });
         if (error) {
             toast.error(error.message);
@@ -80,7 +80,6 @@ const SignUpPage = () => {
                             id="apiKey"
                             value={form.apiKey}
                             onChange={(e) => setForm({ ...form, apiKey: e.target.value })}
-                            required
                         />
                     </div>
                     <Button type="submit" className="w-full" disabled={loading}>

--- a/src/app/(main)/my_page/page.tsx
+++ b/src/app/(main)/my_page/page.tsx
@@ -92,7 +92,6 @@ const MyPage = () => {
             id="apiKey"
             value={form.apiKey}
             onChange={(e) => setForm({ ...form, apiKey: e.target.value })}
-            required
           />
         </div>
         <Button type="submit" className="w-full" disabled={loading}>

--- a/src/app/api/character/[endpoint]/route.ts
+++ b/src/app/api/character/[endpoint]/route.ts
@@ -7,7 +7,8 @@ export const GET = async (
     req: NextRequest,
     context: { params: Promise<{ endpoint: string }> }
 ) => {
-    const apiKey = req.headers.get("x-nxopen-api-key");
+    const apiKey =
+        req.headers.get("x-nxopen-api-key") || process.env.VITE_NEXON_API_KEY;
 
     const handler = GetWithParams<
         { endpoint: string } & Record<string, string>

--- a/src/app/api/character/list/route.ts
+++ b/src/app/api/character/list/route.ts
@@ -11,7 +11,8 @@ interface ICharacterListApiResponse {
 }
 
 export const GET = async (req: Request) => {
-    const apiKey = req.headers.get("x-nxopen-api-key");
+    const apiKey =
+        req.headers.get("x-nxopen-api-key") || process.env.VITE_NEXON_API_KEY;
 
     const handler = Get(async () => {
         if (!apiKey) return Failed("Missing API Key", 500);

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -6,7 +6,8 @@ export const api = axios.create({
 });
 
 api.interceptors.request.use((config) => {
-  const apiKey = userStore.getState().user.apiKey;
+  const apiKey =
+    userStore.getState().user.apiKey || process.env.VITE_NEXON_API_KEY;
   if (apiKey) {
     config.headers = config.headers ?? {};
     config.headers["x-nxopen-api-key"] = apiKey;


### PR DESCRIPTION
## Summary
- default Nexon API key to `VITE_NEXON_API_KEY` when no user key is provided
- make API key optional on sign-up and profile pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3de25cd04832495d6bf4e178e4158