### PR TITLE
feat: show toast on login success

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -34,13 +34,23 @@ const SignInPage = () => {
         if (apiKey) {
             setApiKey(apiKey);
         }
+        toast.success('로그인 성공');
         router.push('/');
         setLoading(false);
     };
 
     const handleGoogle = async () => {
         setGoogleLoading(true);
-        await supabase.auth.signInWithOAuth({ provider: 'google' });
+        const options =
+            window.location.hostname === 'localhost'
+                ? undefined
+                : { redirectTo: window.location.origin };
+
+        await supabase.auth.signInWithOAuth({
+            provider: 'google',
+            options,
+        });
+        toast.success('로그인 성공');
         setGoogleLoading(false);
     };
 


### PR DESCRIPTION
## Summary
- notify users of successful sign in via toast message
- ensure Google OAuth redirects back to the current site only in production

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3df9d0f448324b30e61ac4e1490a5