### PR TITLE
Show verification email toast after sign-up

### DIFF
--- a/src/app/(auth)/sign_up/page.tsx
+++ b/src/app/(auth)/sign_up/page.tsx
@@ -34,6 +34,7 @@ const SignUpPage = () => {
         if (apiKey) {
             setApiKey(apiKey);
         }
+        toast.success(`${form.email}로 인증 메일이 발송되었습니다. 확인해 주세요.`);
         router.push('/');
         setLoading(false);
     };


### PR DESCRIPTION
## Summary
- inform users to check their email for a verification link after signing up

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3fc083cd48324a317acb4cb29353a