### PR TITLE
feat: add skeleton loading for stats

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -147,46 +147,50 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         <ViewTransition enter="fade" exit="fade">
             <ScrollArea id="character-detail-scroll" className="h-page">
                 <div className="space-y-6 p-4">
-                    {loading ? (
-                        <>
-                            <div className="relative w-80 h-80 mx-auto">
-                                <Skeleton className="w-full h-full" />
-                            </div>
-                            <Skeleton className="h-6 w-40 mx-auto" />
-                            <ItemEquipments loading items={[]} />
-                        </>
+                    <div
+                        className="relative w-80 h-80 mx-auto transition-all duration-300"
+                        style={{
+                            transform: `scale(${imageScale})`,
+                            opacity: imageScale,
+                        }}
+                    >
+                        {loading || !basic ? (
+                            <Skeleton className="w-full h-full" />
+                        ) : (
+                            basic.character_image && (
+                                <Image
+                                    src={basic.character_image}
+                                    alt={basic.character_name}
+                                    className="object-contain"
+                                    fill
+                                    priority
+                                />
+                            )
+                        )}
+                    </div>
+                    {loading || !basic ? (
+                        <Skeleton className="h-6 w-40 mx-auto" />
                     ) : (
+                        <p className="text-center font-bold mt-2">{basic.character_name}</p>
+                    )}
+
+                    {/* 주요 스탯 */}
+                    <Stat stat={stat} loading={loading || !stat} />
+                    <Popularity
+                        popularity={popularity?.popularity}
+                        loading={loading || !popularity}
+                    />
+                    <HyperStat hyper={hyper} loading={loading || !hyper} />
+
+                    {/* 장비 */}
+                    <ItemEquipments
+                        items={itemEquip?.item_equipment || []}
+                        loading={loading || !itemEquip}
+                    />
+
+                    {/* 상세 정보는 로딩 완료 후 표시 */}
+                    {!loading && (
                         <>
-                            {/* 캐릭터 기본 정보 */}
-                            {basic && (
-                                <div
-                                    className="relative w-80 h-80 mx-auto transition-all duration-300"
-                                    style={{
-                                        transform: `scale(${imageScale})`,
-                                        opacity: imageScale,
-                                    }}
-                                >
-                                    {basic.character_image && (
-                                        <Image
-                                            src={basic.character_image}
-                                            alt={basic.character_name}
-                                            className="object-contain"
-                                            fill
-                                            priority
-                                        />
-                                    )}
-                                    <p className="text-center font-bold mt-2">{basic.character_name}</p>
-                                </div>
-                            )}
-
-                            {/* 주요 스탯 */}
-                            {stat && <Stat stat={stat} />}
-                            {popularity && <Popularity popularity={popularity.popularity} />}
-                            {hyper && <HyperStat hyper={hyper} />}
-
-                            {/* 장비 */}
-                            {itemEquip && <ItemEquipments items={itemEquip.item_equipment} />}
-
                             {/* 스킬 등 - JSON 프리뷰 */}
                             {Object.entries({
                                 cashEquip,

--- a/src/components/character/detail/HyperStat.tsx
+++ b/src/components/character/detail/HyperStat.tsx
@@ -1,13 +1,44 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ICharacterHyperStat } from "@/interface/character/ICharacter";
 
-export const HyperStat = ({ hyper }: { hyper: ICharacterHyperStat }) => {
+interface HyperStatProps {
+    hyper?: ICharacterHyperStat | null;
+    loading?: boolean;
+}
+
+export const HyperStat = ({ hyper, loading }: HyperStatProps) => {
+    if (loading || !hyper) {
+        return (
+            <Card className="w-full">
+                <CardHeader>
+                    <CardTitle>하이퍼 스탯</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <div className="grid w-full grid-cols-3 gap-2">
+                        {Array.from({ length: 3 }).map((_, i) => (
+                            <Skeleton key={i} className="h-8 w-full" />
+                        ))}
+                    </div>
+                    <ul className="mt-4 space-y-2">
+                        {Array.from({ length: 5 }).map((_, i) => (
+                            <li key={i} className="flex justify-between text-sm">
+                                <Skeleton className="h-4 w-24" />
+                                <Skeleton className="h-4 w-16" />
+                            </li>
+                        ))}
+                    </ul>
+                </CardContent>
+            </Card>
+        );
+    }
+
     const presets = [
         { key: "1", label: "프리셋 1", stats: hyper.hyper_stat_preset_1 },
         { key: "2", label: "프리셋 2", stats: hyper.hyper_stat_preset_2 },
         { key: "3", label: "프리셋 3", stats: hyper.hyper_stat_preset_3 },
-    ]
+    ];
 
     return (
         <Card className="w-full">
@@ -41,6 +72,6 @@ export const HyperStat = ({ hyper }: { hyper: ICharacterHyperStat }) => {
                 </Tabs>
             </CardContent>
         </Card>
-    )
-}
+    );
+};
 

--- a/src/components/character/detail/Popularity.tsx
+++ b/src/components/character/detail/Popularity.tsx
@@ -1,15 +1,25 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 
-export const Popularity = ({ popularity }: { popularity: number }) => {
+interface PopularityProps {
+    popularity?: number;
+    loading?: boolean;
+}
+
+export const Popularity = ({ popularity, loading }: PopularityProps) => {
     return (
         <Card className="w-full">
             <CardHeader>
                 <CardTitle>인기도</CardTitle>
             </CardHeader>
             <CardContent>
-                <p className="text-2xl font-bold text-center">{popularity}</p>
+                {loading ? (
+                    <Skeleton className="h-8 w-20 mx-auto" />
+                ) : (
+                    <p className="text-2xl font-bold text-center">{popularity}</p>
+                )}
             </CardContent>
         </Card>
-    )
-}
+    );
+};
 

--- a/src/components/character/detail/Stat.tsx
+++ b/src/components/character/detail/Stat.tsx
@@ -1,15 +1,25 @@
-import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { ICharacterStat } from "@/interface/character/ICharacter"
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { ICharacterStat } from "@/interface/character/ICharacter";
 
-export const Stat = ({ stat }: { stat: ICharacterStat }) => {
-    const highlights = ["전투력", "보스 몬스터 데미지", "크리티컬 확률", "크리티컬 데미지"]
+interface StatProps {
+    stat?: ICharacterStat | null;
+    loading?: boolean;
+}
+
+export const Stat = ({ stat, loading }: StatProps) => {
+    const highlights = ["전투력", "보스 몬스터 데미지", "크리티컬 확률", "크리티컬 데미지"];
 
     return (
         <Card className="w-full">
             <CardHeader>
-                <CardTitle>{stat.character_class} 스탯</CardTitle>
+                {loading || !stat ? (
+                    <Skeleton className="h-6 w-32" />
+                ) : (
+                    <CardTitle>{stat.character_class} 스탯</CardTitle>
+                )}
             </CardHeader>
             <CardContent>
                 <Table>
@@ -20,22 +30,33 @@ export const Stat = ({ stat }: { stat: ICharacterStat }) => {
                         </TableRow>
                     </TableHeader>
                     <TableBody>
-                        {stat.final_stat.map((s) => (
-                            <TableRow key={s.stat_name}>
-                                <TableCell>
-                                    {highlights.includes(s.stat_name) ? (
-                                        <Badge variant="secondary">{s.stat_name}</Badge>
-                                    ) : (
-                                        s.stat_name
-                                    )}
-                                </TableCell>
-                                <TableCell className="text-right font-medium">{s.stat_value}</TableCell>
-                            </TableRow>
-                        ))}
+                        {loading || !stat
+                            ? Array.from({ length: 4 }).map((_, i) => (
+                                  <TableRow key={i}>
+                                      <TableCell>
+                                          <Skeleton className="h-4 w-24" />
+                                      </TableCell>
+                                      <TableCell className="text-right font-medium">
+                                          <Skeleton className="h-4 w-16 ml-auto" />
+                                      </TableCell>
+                                  </TableRow>
+                              ))
+                            : stat.final_stat.map((s) => (
+                                  <TableRow key={s.stat_name}>
+                                      <TableCell>
+                                          {highlights.includes(s.stat_name) ? (
+                                              <Badge variant="secondary">{s.stat_name}</Badge>
+                                          ) : (
+                                              s.stat_name
+                                          )}
+                                      </TableCell>
+                                      <TableCell className="text-right font-medium">{s.stat_value}</TableCell>
+                                  </TableRow>
+                              ))}
                     </TableBody>
                 </Table>
             </CardContent>
         </Card>
-    )
-}
+    );
+};
 


### PR DESCRIPTION
## Summary
- show Stat, Popularity and HyperStat cards before data fetch with skeleton placeholders
- support skeleton rendering inside each card to keep layout stable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c41d053db883249017818d21a61c9a