### PR TITLE
feat: split detail sections into components

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -3,8 +3,12 @@
 import Image from 'next/image';
 import { unstable_ViewTransition as ViewTransition, useEffect, useState } from 'react';
 import { toast } from "sonner";
+import { CashEquip } from "@/components/character/detail/CashEquip";
+import { HexaStat } from "@/components/character/detail/HexaStat";
 import { HyperStat } from "@/components/character/detail/HyperStat";
+import { JsonSection } from "@/components/character/detail/JsonSection";
 import { Popularity } from "@/components/character/detail/Popularity";
+import { Skill } from "@/components/character/detail/Skill";
 import { Stat } from "@/components/character/detail/Stat";
 import ItemEquipments from "@/components/character/item/ItemEquipments";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -209,40 +213,30 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                     {/* 상세 정보는 로딩 완료 후 표시 */}
                     {!loading && (
                         <>
-                            {/* 스킬 등 - JSON 프리뷰 */}
+                            {/* 스킬 등 */}
+                            <CashEquip equip={cashEquip} loading={!cashEquip} />
+                            <Skill skill={skill} loading={!skill} />
                             {Object.entries({
-                                cashEquip,
                                 symbolEquip,
                                 setEffect,
-                                skill,
                                 linkSkill,
                             }).map(([key, value]) => (
-                                <section key={key} className="w-full">
-                                    <h2 className="text-xl font-bold mb-2">{key}</h2>
-                                    <pre className="text-sm bg-muted p-2 rounded overflow-x-auto max-w-full break-words whitespace-pre-wrap">
-                                        {JSON.stringify(value, null, 2)}
-                                    </pre>
-                                </section>
+                                <JsonSection key={key} title={key} data={value} loading={!value} />
                             ))}
 
-                            {/* 심화 - JSON 프리뷰 */}
+                            {/* 심화 */}
+                            <HexaStat hexaStat={hexaStat} loading={!hexaStat} />
                             {Object.entries({
                                 hexaMatrix,
-                                hexaStat,
                                 vMatrix,
                                 dojang,
                                 ring,
                                 otherStat,
                             }).map(([key, value]) => (
-                                <section key={key}>
-                                    <h2 className="text-xl font-bold mb-2">{key}</h2>
-                                    <pre className="text-sm bg-muted p-2 rounded overflow-x-auto max-w-full break-words whitespace-pre-wrap">
-                                        {JSON.stringify(value, null, 2)}
-                                    </pre>
-                                </section>
+                                <JsonSection key={key} title={key} data={value} loading={!value} />
                             ))}
 
-                            {/* 꾸미기 / 기타 - JSON 프리뷰 */}
+                            {/* 꾸미기 / 기타 */}
                             {Object.entries({
                                 beauty,
                                 android,
@@ -250,12 +244,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                                 propensity,
                                 ability,
                             }).map(([key, value]) => (
-                                <section key={key}>
-                                    <h2 className="text-xl font-bold mb-2">{key}</h2>
-                                    <pre className="text-sm bg-muted p-2 rounded overflow-x-auto max-w-full break-words whitespace-pre-wrap">
-                                        {JSON.stringify(value, null, 2)}
-                                    </pre>
-                                </section>
+                                <JsonSection key={key} title={key} data={value} loading={!value} />
                             ))}
                         </>
                     )}

--- a/src/components/character/detail/CashEquip.tsx
+++ b/src/components/character/detail/CashEquip.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ICharacterCashItemEquipment } from '@/interface/character/ICharacter';
+
+interface CashEquipProps {
+    equip?: ICharacterCashItemEquipment | null;
+    loading?: boolean;
+}
+
+export const CashEquip = ({ equip, loading }: CashEquipProps) => {
+    if (loading || !equip) {
+        return (
+            <Card className="w-full">
+                <CardHeader>
+                    <CardTitle>캐시장비</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <div className="grid grid-cols-4 gap-4">
+                        {Array.from({ length: 8 }).map((_, i) => (
+                            <Skeleton key={i} className="h-10 w-10" />
+                        ))}
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const items = equip.cash_item_equipment_base;
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle>캐시장비</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <div className="grid grid-cols-4 gap-4">
+                    {items.map((item) => (
+                        <div key={item.cash_item_equipment_slot} className="flex flex-col items-center text-center text-xs space-y-1">
+                            <Image src={item.cash_item_icon} alt={item.cash_item_name} width={40} height={40} />
+                            <span>{item.cash_item_name}</span>
+                        </div>
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+

--- a/src/components/character/detail/HexaStat.tsx
+++ b/src/components/character/detail/HexaStat.tsx
@@ -1,0 +1,52 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ICharacterHexaMatrixStat, IHexaStatCore } from '@/interface/character/ICharacter';
+
+interface HexaStatProps {
+    hexaStat?: ICharacterHexaMatrixStat | null;
+    loading?: boolean;
+}
+
+export const HexaStat = ({ hexaStat, loading }: HexaStatProps) => {
+    if (loading || !hexaStat) {
+        return (
+            <Card className="w-full">
+                <CardHeader>
+                    <CardTitle>헥사 스탯</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                    {Array.from({ length: 3 }).map((_, i) => (
+                        <Skeleton key={i} className="h-4 w-full" />
+                    ))}
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const cores: IHexaStatCore[] = [
+        ...hexaStat.character_hexa_stat_core,
+        ...hexaStat.character_hexa_stat_core_2,
+        ...hexaStat.character_hexa_stat_core_3,
+    ];
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle>헥사 스탯</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+                {cores.map((core) => (
+                    <div key={core.slot_id} className="flex justify-between">
+                        <span className="font-medium">
+                            {core.main_stat_name} Lv.{core.main_stat_level}
+                        </span>
+                        <span>
+                            {core.sub_stat_name_1} Lv.{core.sub_stat_level_1} / {core.sub_stat_name_2} Lv.{core.sub_stat_level_2}
+                        </span>
+                    </div>
+                ))}
+            </CardContent>
+        </Card>
+    );
+};
+

--- a/src/components/character/detail/JsonSection.tsx
+++ b/src/components/character/detail/JsonSection.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface JsonSectionProps {
+    title: string;
+    data?: unknown;
+    loading?: boolean;
+}
+
+export const JsonSection = ({ title, data, loading }: JsonSectionProps) => {
+    if (loading || data == null) {
+        return (
+            <Card className="w-full">
+                <CardHeader>
+                    <CardTitle>{title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Skeleton className="h-24 w-full" />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const entries = Array.isArray(data)
+        ? data.map((v, i) => [String(i), v])
+        : Object.entries(data as Record<string, unknown>);
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+                {entries.map(([key, value]) => (
+                    <div key={key} className="flex justify-between gap-2">
+                        <span className="font-medium">{key}</span>
+                        <span className="text-right break-words">
+                            {typeof value === "object" ? JSON.stringify(value) : String(value)}
+                        </span>
+                    </div>
+                ))}
+            </CardContent>
+        </Card>
+    );
+};
+

--- a/src/components/character/detail/Skill.tsx
+++ b/src/components/character/detail/Skill.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ICharacterSkill } from '@/interface/character/ICharacter';
+
+interface SkillProps {
+    skill?: ICharacterSkill[] | null;
+    loading?: boolean;
+}
+
+export const Skill = ({ skill, loading }: SkillProps) => {
+    if (loading || !skill) {
+        return (
+            <Card className="w-full">
+                <CardHeader>
+                    <CardTitle>스킬</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <div className="grid grid-cols-4 gap-4">
+                        {Array.from({ length: 8 }).map((_, i) => (
+                            <Skeleton key={i} className="h-10 w-10" />
+                        ))}
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const skills = skill.flatMap((s) => s.character_skill);
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle>스킬</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <div className="grid grid-cols-4 gap-4">
+                    {skills.map((s) => (
+                        <div key={s.skill_name} className="flex flex-col items-center text-center text-xs space-y-1">
+                            <Image src={s.skill_icon} alt={s.skill_name} width={40} height={40} />
+                            <span>{s.skill_name}</span>
+                        </div>
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+


### PR DESCRIPTION
## Summary
- introduce dedicated Skill, CashEquip, and HexaStat components for character detail view
- render these components in CharacterDetail instead of generic JsonSection blocks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c5075009588324b8c6ae02b664b8b8