### PR TITLE
fix: prevent premature google login success toast

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -59,12 +59,14 @@ const SignInPage = () => {
                 ? undefined
                 : { redirectTo: window.location.origin };
 
-        await supabase.auth.signInWithOAuth({
+        const { error } = await supabase.auth.signInWithOAuth({
             provider: 'google',
             options,
         });
-        toast.success('로그인 성공');
-        setGoogleLoading(false);
+        if (error) {
+            toast.error(error.message);
+            setGoogleLoading(false);
+        }
     };
 
     return (


### PR DESCRIPTION
## Summary
- remove immediate success toast for Google login
- show error toast on OAuth failure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c54d1c0470832489f18f494924de4d