### PR TITLE
Fix dark mode background for mobile dialog

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -118,7 +118,7 @@ const Home = () => {
                     <DialogContent
                         className="
                             absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                            w-[90vw] max-w-md rounded-2xl shadow-lg bg-white
+                            w-[90vw] max-w-md rounded-2xl shadow-lg bg-background
                         "
                     >
                         <DialogTitle className="px-4 pt-4">Info</DialogTitle>


### PR DESCRIPTION
## Summary
- use theme background for mobile dialog to respect dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5507de20083248deef346ac1a3c2f