### PR TITLE
fix: prevent invalid cast in pet view

### DIFF
--- a/src/components/character/detail/Pet.tsx
+++ b/src/components/character/detail/Pet.tsx
@@ -26,13 +26,11 @@ export const Pet = ({ pet, loading }: PetProps) => {
         );
     }
 
-    const petData = pet as Record<string, string>;
-    const pets = [1, 2, 3]
-        .map((i) => ({
-            name: petData[`pet_${i}_name`],
-            icon: petData[`pet_${i}_icon`],
-        }))
-        .filter((p) => p.name);
+    const pets = [
+        { name: pet.pet_1_name, icon: pet.pet_1_icon },
+        { name: pet.pet_2_name, icon: pet.pet_2_icon },
+        { name: pet.pet_3_name, icon: pet.pet_3_icon },
+    ].filter((p) => p.name);
 
     return (
         <Card className="w-full">

--- a/src/interface/character/ICharacter.ts
+++ b/src/interface/character/ICharacter.ts
@@ -364,7 +364,12 @@ export interface ICharacterPetEquipment {
     pet_1_name: string
     pet_1_icon: string
     pet_1_description: string
-    // ... (펫2, 펫3도 동일 구조)
+    pet_2_name: string
+    pet_2_icon: string
+    pet_2_description: string
+    pet_3_name: string
+    pet_3_icon: string
+    pet_3_description: string
 }
 
 export interface ICharacterPropensity {


### PR DESCRIPTION
## Summary
- avoid unsafe Record cast for pet data
- define additional pet fields in interface

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `NEXT_DISABLE_GOOGLE_FONT_OPTIMIZATION=1 npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c55231871483249c923a05df3dd4c8