### PR TITLE
Improve mobile dialog layout and equipment card padding

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -117,8 +117,9 @@ const Home = () => {
                 <Dialog open={open} onOpenChange={setOpen}>
                     <DialogContent
                         className="
-                            absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                            w-[90vw] max-w-md rounded-2xl shadow-lg bg-background
+                            fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
+                            w-[90vw] max-w-md max-h-[90vh] overflow-y-auto
+                            rounded-2xl bg-background p-0 shadow-lg
                         "
                     >
                         <DialogTitle className="px-4 pt-4">Info</DialogTitle>

--- a/src/components/character/item/ItemEquipments.tsx
+++ b/src/components/character/item/ItemEquipments.tsx
@@ -49,7 +49,7 @@ const ItemEquipments = ({ items = [], loading }: IEquipmentGrid) => {
             <CardHeader>
                 <CardTitle>장비</CardTitle>
             </CardHeader>
-            <CardContent className="flex justify-center">
+            <CardContent className="flex w-full justify-center">
                 <div className="grid grid-cols-5 grid-rows-6 gap-2 p-4 bg-muted rounded-lg w-fit">
                     {Object.entries(slotPosition).map(([slot, pos]) => {
                         const equip = items.find((item) => item.item_equipment_slot === slot);


### PR DESCRIPTION
## Summary
- Prevent mobile dialog from overflowing the viewport and add scrolling
- Ensure equipment card keeps right-side padding

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c55a51e40c8324ac7616695d4b413a