### PR TITLE
feat: add skill tabs

### DIFF
--- a/src/components/character/detail/Skill.tsx
+++ b/src/components/character/detail/Skill.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ICharacterSkill } from '@/interface/character/ICharacter';
 
 interface SkillProps {
@@ -26,7 +27,8 @@ export const Skill = ({ skill, loading }: SkillProps) => {
         );
     }
 
-    const skills = skill.flatMap((s) => s.character_skill);
+    const grades = skill.slice(1, 7); // 1~6차 전직 스킬
+    const romans = ['I', 'II', 'III', 'IV', 'V', 'VI'];
 
     return (
         <Card className="w-full">
@@ -34,14 +36,35 @@ export const Skill = ({ skill, loading }: SkillProps) => {
                 <CardTitle>스킬</CardTitle>
             </CardHeader>
             <CardContent>
-                <div className="grid grid-cols-4 gap-4">
-                    {skills.map((s) => (
-                        <div key={s.skill_name} className="flex flex-col items-center text-center text-xs space-y-1">
-                            <Image src={s.skill_icon} alt={s.skill_name} width={40} height={40} />
-                            <span>{s.skill_name}</span>
-                        </div>
+                <Tabs defaultValue={romans[0]} className="w-full">
+                    <TabsList className="grid w-full grid-cols-6">
+                        {grades.map((_, i) => (
+                            <TabsTrigger key={romans[i]} value={romans[i]}>
+                                {romans[i]}
+                            </TabsTrigger>
+                        ))}
+                    </TabsList>
+                    {grades.map((g, i) => (
+                        <TabsContent key={romans[i]} value={romans[i]}>
+                            <div className="grid grid-cols-4 gap-4">
+                                {g?.character_skill.map((s) => (
+                                    <div
+                                        key={s.skill_name}
+                                        className="flex flex-col items-center text-center text-xs space-y-1"
+                                    >
+                                        <Image
+                                            src={s.skill_icon}
+                                            alt={s.skill_name}
+                                            width={40}
+                                            height={40}
+                                        />
+                                        <span>{s.skill_name}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        </TabsContent>
                     ))}
-                </div>
+                </Tabs>
             </CardContent>
         </Card>
     );


### PR DESCRIPTION
## Summary
- add tabbed navigation for skills I-VI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c79d9768a483249a6db94990bd5e54