### PR TITLE
style: improve character detail layout

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -176,7 +176,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
     return (
         <ViewTransition enter="fade" exit="fade">
             <ScrollArea id="character-detail-scroll" className="h-page">
-                <div className="space-y-6 p-4 w-full max-w-xl mx-auto lg:max-w-3xl">
+                <div className="space-y-6 p-4 w-full max-w-5xl mx-auto">
                     <div
                         className="relative w-80 h-80 mx-auto"
                         style={{
@@ -204,13 +204,17 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                         <p className="text-center font-bold mt-2">{basic.character_name}</p>
                     )}
 
-                    {/* 주요 스탯 */}
-                    <Stat stat={stat} loading={basicLoading || !stat} />
-                    <Popularity
-                        popularity={popularity?.popularity}
-                        loading={basicLoading || !popularity}
-                    />
-                    <HyperStat hyper={hyper} loading={basicLoading || !hyper} />
+                    <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+                        <div className="space-y-4">
+                            <Stat stat={stat} loading={basicLoading || !stat} />
+                            <Popularity
+                                popularity={popularity?.popularity}
+                                loading={basicLoading || !popularity}
+                            />
+                            <HyperStat hyper={hyper} loading={basicLoading || !hyper} />
+                        </div>
+                        <Ability ability={ability} loading={!ability} />
+                    </div>
 
                     {/* 장비 */}
                     <ItemEquipments
@@ -239,7 +243,6 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                     <Android android={android} loading={!android} />
                     <Pet pet={pet} loading={!pet} />
                     <Propensity propensity={propensity} loading={!propensity} />
-                    <Ability ability={ability} loading={!ability} />
                 </div>
             </ScrollArea>
         </ViewTransition>

--- a/src/components/character/detail/Ability.tsx
+++ b/src/components/character/detail/Ability.tsx
@@ -2,6 +2,15 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ICharacterAbility } from '@/interface/character/ICharacter';
 
+const gradeStyles: Record<string, string> = {
+    레전드리:
+        'bg-green-500 text-green-950 dark:bg-green-600 dark:text-green-50',
+    유니크:
+        'bg-yellow-300 text-yellow-950 dark:bg-yellow-500 dark:text-yellow-950',
+    에픽: 'bg-violet-500 text-violet-50 dark:bg-violet-600 dark:text-violet-50',
+    레어: 'bg-blue-500 text-blue-50 dark:bg-blue-600 dark:text-blue-50',
+};
+
 interface AbilityProps {
     ability?: ICharacterAbility | null;
     loading?: boolean;
@@ -26,9 +35,14 @@ export const Ability = ({ ability, loading }: AbilityProps) => {
             <CardHeader>
                 <CardTitle>어빌리티</CardTitle>
             </CardHeader>
-            <CardContent className="text-sm space-y-1">
+            <CardContent className="text-sm space-y-2">
                 {ability.ability_info.map((a) => (
-                    <p key={a.ability_no}>{a.ability_value}</p>
+                    <div
+                        key={a.ability_no}
+                        className={`rounded px-2 py-1 text-center font-medium ${gradeStyles[a.ability_grade] || ''}`}
+                    >
+                        {a.ability_value}
+                    </div>
                 ))}
             </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- show stats and ability side-by-side for a denser character detail header
- color-code ability lines based on their grades

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a0304f408324a8cdbbb79dbea3f7