### PR TITLE
feat: organize character detail into tabs

### DIFF
--- a/src/components/character/detail/Ability.tsx
+++ b/src/components/character/detail/Ability.tsx
@@ -2,6 +2,15 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ICharacterAbility } from '@/interface/character/ICharacter';
 
+const gradeStyles: Record<string, string> = {
+    레전드리:
+        'bg-green-500 text-green-950 dark:bg-green-600 dark:text-green-50',
+    유니크:
+        'bg-yellow-300 text-yellow-950 dark:bg-yellow-500 dark:text-yellow-950',
+    에픽: 'bg-violet-500 text-violet-50 dark:bg-violet-600 dark:text-violet-50',
+    레어: 'bg-blue-500 text-blue-50 dark:bg-blue-600 dark:text-blue-50',
+};
+
 interface AbilityProps {
     ability?: ICharacterAbility | null;
     loading?: boolean;
@@ -26,9 +35,14 @@ export const Ability = ({ ability, loading }: AbilityProps) => {
             <CardHeader>
                 <CardTitle>어빌리티</CardTitle>
             </CardHeader>
-            <CardContent className="text-sm space-y-1">
+            <CardContent className="text-sm space-y-2">
                 {ability.ability_info.map((a) => (
-                    <p key={a.ability_no}>{a.ability_value}</p>
+                    <div
+                        key={a.ability_no}
+                        className={`rounded px-2 py-1 text-center font-medium ${gradeStyles[a.ability_grade] || ''}`}
+                    >
+                        {a.ability_value}
+                    </div>
                 ))}
             </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- add tabbed navigation to split character detail into basic info, equipment, skill, cash, and misc
- load equipment, skill, cash, and misc data on demand when their tab is opened
- show popularity and hyper stats alongside ability in the basic tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a0304f408324a8cdbbb79dbea3f7