### PR TITLE
feat: add union detail tab and API

### DIFF
--- a/src/app/api/union/[endpoint]/route.ts
+++ b/src/app/api/union/[endpoint]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from "next/server";
+import axios, { AxiosError } from "axios";
+import { GetWithParams } from "@/libs/fetch";
+import { Failed, Success } from "@/libs/message";
+
+export const GET = async (
+    req: NextRequest,
+    context: { params: Promise<{ endpoint: string }> }
+) => {
+    const apiKey =
+        req.headers.get("x-nxopen-api-key") || process.env.VITE_NEXON_API_KEY;
+
+    const handler = GetWithParams<
+        { endpoint: string } & Record<string, string>
+    >(async (params) => {
+        if (!apiKey) return Failed("Missing API Key", 500);
+
+        const { endpoint, ...query } = params;
+
+        try {
+            const res = await axios.get(
+                `https://open.api.nexon.com/maplestory/v1/user/${endpoint}`,
+                {
+                    params: query,
+                    headers: { "x-nxopen-api-key": apiKey },
+                }
+            );
+            return Success("유니온 정보 조회 성공", 200, { data: res.data });
+        } catch (err: unknown) {
+            if (err instanceof AxiosError) {
+                const message =
+                    err.response?.data?.error?.message ?? err.message;
+                const status = err.response?.status ?? 500;
+                return Failed(message, status);
+            }
+            if (err instanceof Error) return Failed(err.message, 500);
+            return Failed("Unknown error", 500);
+        }
+    });
+
+    return handler(req, context);
+};

--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -21,6 +21,7 @@ import { SetEffect } from "@/components/character/detail/SetEffect";
 import { Skill } from "@/components/character/detail/Skill";
 import { Stat } from "@/components/character/detail/Stat";
 import { SymbolEquip } from "@/components/character/detail/SymbolEquip";
+import { Union } from "@/components/character/detail/Union";
 import { VMatrix } from "@/components/character/detail/VMatrix";
 import ItemEquipments from "@/components/character/item/ItemEquipments";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -49,15 +50,18 @@ import {
     findCharacterSymbolEquipment,
     findCharacterVMatrix,
 } from '@/fetchs/character.fetch';
+import { findUnion, findUnionRaider, findUnionArtifact } from '@/fetchs/union.fetch';
 import { characterDetailStore } from "@/stores/characterDetailStore";
 
 const CharacterDetail = ({ ocid }: { ocid: string }) => {
     const {
         basic, stat, popularity, hyper,
+        union, unionRaider, unionArtifact,
         itemEquip, cashEquip, symbolEquip, setEffect, skill, linkSkill,
         hexaMatrix, hexaStat, vMatrix, dojang, ring, otherStat,
         beauty, android, pet, propensity, ability,
         setBasic, setStat, setPopularity, setHyper,
+        setUnion, setUnionRaider, setUnionArtifact,
         setItemEquip, setCashEquip, setSymbolEquip, setSetEffect, setSkill, setLinkSkill,
         setHexaMatrix, setHexaStat, setVMatrix, setDojang, setRing, setOtherStat,
         setBeauty, setAndroid, setPet, setPropensity, setAbility,
@@ -98,6 +102,27 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         setTab("basic");
         load();
     }, [ocid, reset, setBasic, setStat, setPopularity, setHyper, setAbility]);
+
+    // 유니온 탭 로딩
+    useEffect(() => {
+        if (tab !== "union" || (union && unionRaider && unionArtifact)) return;
+        const loadUnion = async () => {
+            try {
+                const [unionRes, raiderRes, artifactRes] = await Promise.all([
+                    findUnion(ocid),
+                    findUnionRaider(ocid),
+                    findUnionArtifact(ocid),
+                ]);
+                setUnion(unionRes.data);
+                setUnionRaider(raiderRes.data);
+                setUnionArtifact(artifactRes.data);
+            } catch (e) {
+                console.error(e);
+                toast.error('유니온 정보 로딩 실패');
+            }
+        };
+        loadUnion();
+    }, [tab, ocid, union, unionRaider, unionArtifact, setUnion, setUnionRaider, setUnionArtifact]);
 
     // 장비 탭 로딩
     useEffect(() => {
@@ -291,6 +316,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                     <Tabs value={tab} onValueChange={setTab} className="space-y-4">
                         <TabsList>
                             <TabsTrigger value="basic">기본정보</TabsTrigger>
+                            <TabsTrigger value="union">유니온</TabsTrigger>
                             <TabsTrigger value="equip">장비</TabsTrigger>
                             <TabsTrigger value="skill">스킬</TabsTrigger>
                             <TabsTrigger value="cash">캐시</TabsTrigger>
@@ -311,6 +337,10 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                                     <HyperStat hyper={hyper} loading={basicLoading || !hyper} />
                                 </div>
                             </div>
+                        </TabsContent>
+
+                        <TabsContent value="union" className="space-y-4">
+                            <Union union={union} raider={unionRaider} artifact={unionArtifact} loading={!union || !unionRaider || !unionArtifact} />
                         </TabsContent>
 
                         <TabsContent value="equip" className="space-y-4">

--- a/src/components/character/detail/Union.tsx
+++ b/src/components/character/detail/Union.tsx
@@ -1,0 +1,60 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { IUnion, IUnionArtifact, IUnionRaider } from '@/interface/union/IUnion';
+
+interface UnionProps {
+    union?: IUnion | null;
+    raider?: IUnionRaider | null;
+    artifact?: IUnionArtifact | null;
+    loading?: boolean;
+}
+
+export const Union = ({ union, raider, artifact, loading }: UnionProps) => {
+    if (loading || !union || !raider || !artifact) {
+        return (
+            <Card className="w-full">
+                <CardHeader>
+                    <CardTitle>유니온</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Skeleton className="h-6 w-full" />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle>유니온</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+                <div>레벨: {union.union_level}</div>
+                <div>등급: {union.union_grade}</div>
+                <div>아티팩트 레벨: {union.union_artifact_level}</div>
+                {raider.union_raider_stat.length > 0 && (
+                    <div>
+                        <div className="font-medium">공격대원 효과</div>
+                        <ul className="list-disc pl-5">
+                            {raider.union_raider_stat.map((s) => (
+                                <li key={s}>{s}</li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+                {artifact.union_artifact_effect.length > 0 && (
+                    <div>
+                        <div className="font-medium">아티팩트 효과</div>
+                        <ul className="list-disc pl-5">
+                            {artifact.union_artifact_effect.map((e) => (
+                                <li key={e.name}>{e.name} Lv.{e.level}</li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+};
+
+export default Union;

--- a/src/fetchs/union.fetch.ts
+++ b/src/fetchs/union.fetch.ts
@@ -1,0 +1,54 @@
+import axios, { AxiosError } from "axios";
+import { IUnion, IUnionRaider, IUnionArtifact, IUnionChampion } from "@/interface/union/IUnion";
+import { IUnionResponse } from "@/interface/union/IUnionResponse";
+import { userStore } from "@/stores/userStore";
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+let requestQueue: Promise<unknown> = Promise.resolve();
+
+const callUnionApi = async <T>(
+    endpoint: string,
+    params: Record<string, string | number | undefined> = {}
+): Promise<IUnionResponse<T>> => {
+    const apiKey = userStore.getState().user.apiKey;
+
+    const task = async () => {
+        await delay(200);
+        try {
+            const response = await axios.get<IUnionResponse<T>>(`/api/union/${endpoint}`, {
+                headers: { "x-nxopen-api-key": apiKey ?? "" },
+                params: Object.fromEntries(
+                    Object.entries(params).filter(([, v]) => v !== undefined)
+                ),
+            });
+            return response.data;
+        } catch (err) {
+            if (
+                err instanceof AxiosError &&
+                err.response?.data?.error?.message === "Missing API Key"
+            ) {
+                if (typeof window !== "undefined") {
+                    window.location.href = "/my_page?missingApiKey=1";
+                }
+            }
+            throw err;
+        }
+    };
+
+    const result = requestQueue.then(task);
+    requestQueue = result.catch(() => undefined);
+    return result;
+};
+
+export const findUnion = (ocid: string, date?: string) =>
+    callUnionApi<IUnion>("union", { ocid, date });
+
+export const findUnionRaider = (ocid: string, date?: string) =>
+    callUnionApi<IUnionRaider>("union-raider", { ocid, date });
+
+export const findUnionArtifact = (ocid: string, date?: string) =>
+    callUnionApi<IUnionArtifact>("union-artifact", { ocid, date });
+
+export const findUnionChampion = (ocid: string, date?: string) =>
+    callUnionApi<IUnionChampion>("union-champion", { ocid, date });

--- a/src/interface/union/IUnion.ts
+++ b/src/interface/union/IUnion.ts
@@ -1,0 +1,78 @@
+export interface IUnion {
+    date: string;
+    union_level: number;
+    union_grade: string;
+    union_artifact_level: number;
+    union_artifact_exp: number;
+    union_artifact_point: number;
+}
+
+export interface IUnionRaiderInnerStat {
+    stat_field_id: string;
+    stat_field_effect: string;
+}
+
+export interface IUnionRaiderBlock {
+    block_type: string;
+    block_class: string;
+    block_level: string;
+    block_control_point: { x: number; y: number };
+    block_position: { x: number; y: number }[];
+}
+
+export interface IUnionRaiderPreset {
+    union_raider_stat: string[];
+    union_occupied_stat: string[];
+    union_inner_stat: IUnionRaiderInnerStat[];
+    union_block: IUnionRaiderBlock[];
+}
+
+export interface IUnionRaider extends IUnionRaiderPreset {
+    date: string;
+    use_preset_no: number;
+    union_raider_preset_1: IUnionRaiderPreset;
+    union_raider_preset_2: IUnionRaiderPreset;
+    union_raider_preset_3: IUnionRaiderPreset;
+    union_raider_preset_4: IUnionRaiderPreset;
+    union_raider_preset_5: IUnionRaiderPreset;
+}
+
+export interface IUnionArtifactEffect {
+    name: string;
+    level: number;
+}
+
+export interface IUnionArtifactCrystal {
+    name: string;
+    validity_flag: string;
+    date_expire: string | null;
+    level: number;
+    crystal_option_name_1: string;
+    crystal_option_name_2: string;
+    crystal_option_name_3: string;
+}
+
+export interface IUnionArtifact {
+    date: string;
+    union_artifact_effect: IUnionArtifactEffect[];
+    union_artifact_crystal: IUnionArtifactCrystal[];
+    union_artifact_remain_ap: number;
+}
+
+export interface IUnionChampionBadgeInfo {
+    stat: string;
+}
+
+export interface IUnionChampionInfo {
+    champion_name: string;
+    champion_slot: number;
+    champion_grade: string;
+    champion_class: string;
+    champion_badge_info: IUnionChampionBadgeInfo[];
+}
+
+export interface IUnionChampion {
+    date: string;
+    union_champion: IUnionChampionInfo[];
+    champion_badge_total_info: IUnionChampionBadgeInfo[];
+}

--- a/src/interface/union/IUnionResponse.ts
+++ b/src/interface/union/IUnionResponse.ts
@@ -1,0 +1,5 @@
+export interface IUnionResponse<T> {
+    message: string;
+    status: number;
+    data: T;
+}

--- a/src/stores/characterDetailStore.ts
+++ b/src/stores/characterDetailStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { ICharacterAbility, ICharacterAndroidEquipment, ICharacterBasic, ICharacterBeautyEquipment, ICharacterCashItemEquipment, ICharacterDojang, ICharacterHexaMatrix, ICharacterHexaMatrixStat, ICharacterHyperStat, ICharacterItemEquipment, ICharacterLinkSkill, ICharacterOtherStat, ICharacterPetEquipment, ICharacterPopularity, ICharacterPropensity, ICharacterSetEffect, ICharacterSkill, ICharacterStat, ICharacterSymbolEquipment, ICharacterVMatrix, IRingExchangeSkillEquipment, } from "@/interface/character/ICharacter";
+import { IUnion, IUnionRaider, IUnionArtifact, IUnionChampion } from "@/interface/union/IUnion";
 
 type CharacterDetailSlice = {
     // 기본 정보
@@ -8,6 +9,12 @@ type CharacterDetailSlice = {
     stat: ICharacterStat | null
     popularity: ICharacterPopularity | null
     hyper: ICharacterHyperStat | null
+
+    // 유니온
+    union: IUnion | null
+    unionRaider: IUnionRaider | null
+    unionArtifact: IUnionArtifact | null
+    unionChampion: IUnionChampion | null
 
     // 장비 / 스킬
     itemEquip: ICharacterItemEquipment | null
@@ -37,6 +44,10 @@ type CharacterDetailSlice = {
     setStat: (stat: CharacterDetailSlice['stat']) => void
     setPopularity: (popularity: CharacterDetailSlice['popularity']) => void
     setHyper: (hyper: CharacterDetailSlice['hyper']) => void
+    setUnion: (union: CharacterDetailSlice['union']) => void
+    setUnionRaider: (unionRaider: CharacterDetailSlice['unionRaider']) => void
+    setUnionArtifact: (unionArtifact: CharacterDetailSlice['unionArtifact']) => void
+    setUnionChampion: (unionChampion: CharacterDetailSlice['unionChampion']) => void
     setItemEquip: (itemEquip: CharacterDetailSlice['itemEquip']) => void
     setCashEquip: (cashEquip: CharacterDetailSlice['cashEquip']) => void
     setSymbolEquip: (symbolEquip: CharacterDetailSlice['symbolEquip']) => void
@@ -82,12 +93,21 @@ const initialState: Omit<
     | 'setPet'
     | 'setPropensity'
     | 'setAbility'
+    | 'setUnion'
+    | 'setUnionRaider'
+    | 'setUnionArtifact'
+    | 'setUnionChampion'
     | 'reset'
 > = {
     basic: null,
     stat: null,
     popularity: null,
     hyper: null,
+
+    union: null,
+    unionRaider: null,
+    unionArtifact: null,
+    unionChampion: null,
 
     itemEquip: null,
     cashEquip: null,
@@ -119,6 +139,10 @@ export const characterDetailStore = create<CharacterDetailSlice>()(
             setStat: (stat) => set({ stat }),
             setPopularity: (popularity) => set({ popularity }),
             setHyper: (hyper) => set({ hyper }),
+            setUnion: (union) => set({ union }),
+            setUnionRaider: (unionRaider) => set({ unionRaider }),
+            setUnionArtifact: (unionArtifact) => set({ unionArtifact }),
+            setUnionChampion: (unionChampion) => set({ unionChampion }),
             setItemEquip: (itemEquip) => set({ itemEquip }),
             setCashEquip: (cashEquip) => set({ cashEquip }),
             setSymbolEquip: (symbolEquip) => set({ symbolEquip }),


### PR DESCRIPTION
## Summary
- add interfaces and fetch logic for union APIs
- show union data in new character detail tab
- proxy union requests through API route

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ad5b64b08324ad58fdc3cf2237af