### PR TITLE
Crop character images and parallelize list loading

### DIFF
--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -47,7 +47,7 @@ const CharacterCard = ({
             <div className="relative w-full aspect-[4/3] mb-4">
                 {character.image && (
                     <Image
-                        src={character.image}
+                        src={`/api/crop?url=${encodeURIComponent(character.image)}`}
                         alt={character.character_name}
                         className="object-contain"
                         sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"

--- a/src/components/home/CharacterInfo.tsx
+++ b/src/components/home/CharacterInfo.tsx
@@ -70,7 +70,7 @@ const CharacterInfo = ({ ocid, goToDetailPage, className }: ICharacterInfoProps)
                                 basic.character_image && (
                                     <div className="relative w-64 h-64 mt-4">
                                         <Image
-                                            src={basic.character_image}
+                                            src={`/api/crop?url=${encodeURIComponent(basic.character_image)}`}
                                             alt={basic.character_name}
                                             fill
                                             className="object-contain"

--- a/src/stores/characterListStore.ts
+++ b/src/stores/characterListStore.ts
@@ -27,18 +27,16 @@ export const characterListStore = create<CharacterListSlice>()(persist((set) => 
                 const sorted = basicList.sort((a, b) => b.character_level - a.character_level);
                 set({ characters: sorted, loading: false });
 
-                const loadImages = async () => {
-                    for (const char of sorted) {
+                await Promise.all(
+                    sorted.map(async (char) => {
                         const data = await findCharacterBasic(char.ocid);
                         set((state) => ({
                             characters: state.characters.map((c) =>
                                 c.ocid === char.ocid ? { ...c, image: data.data.character_image } : c
                             ),
                         }));
-                    }
-                };
-
-                await loadImages();
+                    })
+                );
             } catch (err) {
                 set({ loading: false });
                 throw err;


### PR DESCRIPTION
## Summary
- Load character images through crop API in info and card views
- Fetch character list images in parallel for faster loading

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c7ca4e55d0832481a6b1dbc4775792