### PR TITLE
feat: show skill details tooltip

### DIFF
--- a/src/components/character/detail/Skill.tsx
+++ b/src/components/character/detail/Skill.tsx
@@ -1,8 +1,10 @@
 import Image from 'next/image';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ICharacterSkill } from '@/interface/character/ICharacter';
+import SkillDetail from './SkillDetail';
 
 interface SkillProps {
     skill?: ICharacterSkill[] | null;
@@ -48,18 +50,22 @@ export const Skill = ({ skill, loading }: SkillProps) => {
                         <TabsContent key={romans[i]} value={romans[i]}>
                             <div className="grid grid-cols-4 gap-4">
                                 {g?.character_skill.map((s) => (
-                                    <div
-                                        key={s.skill_name}
-                                        className="flex flex-col items-center text-center text-xs space-y-1"
-                                    >
-                                        <Image
-                                            src={s.skill_icon}
-                                            alt={s.skill_name}
-                                            width={40}
-                                            height={40}
-                                        />
-                                        <span>{s.skill_name}</span>
-                                    </div>
+                                    <Popover key={s.skill_name}>
+                                        <PopoverTrigger asChild>
+                                            <div className="flex flex-col items-center text-center text-xs space-y-1 cursor-pointer">
+                                                <Image
+                                                    src={s.skill_icon}
+                                                    alt={s.skill_name}
+                                                    width={40}
+                                                    height={40}
+                                                />
+                                                <span>{s.skill_name}</span>
+                                            </div>
+                                        </PopoverTrigger>
+                                        <PopoverContent className="p-0 bg-transparent border-none shadow-none">
+                                            <SkillDetail skill={s} />
+                                        </PopoverContent>
+                                    </Popover>
                                 ))}
                             </div>
                         </TabsContent>

--- a/src/components/character/detail/SkillDetail.tsx
+++ b/src/components/character/detail/SkillDetail.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import { ICharacterSkill } from "@/interface/character/ICharacter";
+
+interface SkillDetailProps {
+    skill: ICharacterSkill["character_skill"][number];
+}
+
+const SkillDetail = ({ skill }: SkillDetailProps) => {
+    return (
+        <div className="bg-black/85 text-white rounded-lg shadow-lg p-4 max-w-xs">
+            <div className="flex items-center gap-3 mb-2">
+                <div className="relative w-10 h-10 flex-shrink-0">
+                    <Image
+                        src={skill.skill_icon}
+                        alt={skill.skill_name}
+                        fill
+                        className="object-contain"
+                        sizes="40px"
+                    />
+                </div>
+                <div>
+                    <h3 className="font-bold text-sm">{skill.skill_name}</h3>
+                    <p className="text-xs">Lv. {skill.skill_level}</p>
+                </div>
+            </div>
+            {skill.skill_description && (
+                <p className="text-xs mb-1 whitespace-pre-line">
+                    {skill.skill_description}
+                </p>
+            )}
+            {skill.skill_effect && (
+                <p className="text-xs whitespace-pre-line">
+                    {skill.skill_effect}
+                </p>
+            )}
+        </div>
+    );
+};
+
+export default SkillDetail;
+


### PR DESCRIPTION
## Summary
- add `SkillDetail` component to display name, level and description
- show skill details in a popover when clicking skill icons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7d2afec748324891fe7b2c6f777ad