### PR TITLE
fix: enable CORS for crop API

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,27 @@ const nextConfig: NextConfig = {
     experimental: {
         viewTransition: true,
     },
+    async headers() {
+        return [
+            {
+                source: "/api/crop",
+                headers: [
+                    {
+                        key: "Access-Control-Allow-Origin",
+                        value: "*",
+                    },
+                    {
+                        key: "Access-Control-Allow-Methods",
+                        value: "GET, OPTIONS",
+                    },
+                    {
+                        key: "Access-Control-Allow-Headers",
+                        value: "*",
+                    },
+                ],
+            },
+        ];
+    },
 };
 
 export default nextConfig;

--- a/src/app/api/crop/route.ts
+++ b/src/app/api/crop/route.ts
@@ -3,12 +3,27 @@ import { Get } from "@/utils/fetch";
 import { Failed } from "@/utils/message";
 
 export const GET = Get(async (query: { url?: string }) => {
-    if (!query.url)  return Failed('url is required')
+    if (!query.url) return Failed("url is required");
 
     const response = await fetch(query.url);
     const buffer = Buffer.from(await response.arrayBuffer());
     const cropped = await sharp(buffer).trim().png().toBuffer();
     const uint8 = new Uint8Array(cropped); // Buffer → Uint8Array 변환 (Response에서 안전하게 사용 가능)
 
-    return new Response(uint8, {headers: { "Content-Type": "image/png" },});
+    return new Response(uint8, {
+        headers: {
+            "Content-Type": "image/png",
+            "Access-Control-Allow-Origin": "*",
+        },
+    });
 });
+
+export const OPTIONS = async () =>
+    new Response(null, {
+        status: 204,
+        headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, OPTIONS",
+            "Access-Control-Allow-Headers": "*",
+        },
+    });


### PR DESCRIPTION
## Summary
- allow cross-origin requests on `/api/crop`
- add CORS headers in Next.js config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d57604cc83248b136060248d2e9a