### PR TITLE
fix: ensure crop API runs on node runtime

### DIFF
--- a/src/app/api/crop/route.ts
+++ b/src/app/api/crop/route.ts
@@ -2,6 +2,9 @@ import sharp from "sharp";
 import { Get } from "@/utils/fetch";
 import { Failed } from "@/utils/message";
 
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
 export const GET = Get(async (query: { url?: string }) => {
     if (!query.url) return Failed("url is required");
 


### PR DESCRIPTION
## Summary
- ensure crop API uses Node runtime and runs dynamically to avoid missing images on Vercel

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve 'recharts')*

------
https://chatgpt.com/codex/tasks/task_e_68c7d9171ff0832494f76a015754e9f3