### PR TITLE
fix: return valid body in crop api

### DIFF
--- a/src/app/api/crop/route.ts
+++ b/src/app/api/crop/route.ts
@@ -17,8 +17,10 @@ export const GET = Get(async (query: { url?: string }) => {
 
     const buffer = Buffer.from(await response.arrayBuffer());
     const cropped = await sharp(buffer).trim().png().toBuffer();
+    const uint8 = new Uint8Array(cropped);
+    const blob = new Blob([uint8], { type: "image/png" });
 
-    return new Response(cropped, {
+    return new Response(blob, {
         headers: {
             "Content-Type": "image/png",
             "Access-Control-Allow-Origin": "*",

--- a/src/components/character/detail/Propensity.tsx
+++ b/src/components/character/detail/Propensity.tsx
@@ -43,8 +43,6 @@ export const Propensity = ({ propensity, loading }: PropensityProps) => {
         { subject: '매력', value: propensity.charm_level },
     ];
 
-    const maxValue = Math.max(100, ...data.map((d) => d.value));
-
     // 커스텀 툴팁
     const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
         if (active && payload && payload.length > 0) {


### PR DESCRIPTION
## Summary
- return cropped image as Blob so the API Response body matches BodyInit
- remove unused propensity variable

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ded6cde083249f3933f3878c8b35