### PR TITLE
feat: add auction page with Nexon API data

### DIFF
--- a/src/app/(main)/auction/page.tsx
+++ b/src/app/(main)/auction/page.tsx
@@ -1,0 +1,7 @@
+import AuctionList from "@/components/auction/AuctionList";
+
+const AuctionPage = () => {
+    return <AuctionList />;
+};
+
+export default AuctionPage;

--- a/src/app/api/auction/[endpoint]/route.ts
+++ b/src/app/api/auction/[endpoint]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from "next/server";
+import axios, { AxiosError } from "axios";
+import { GetWithParams } from "@/utils/fetch";
+import { Failed, Success } from "@/utils/message";
+
+export const GET = async (
+    req: NextRequest,
+    context: { params: Promise<{ endpoint: string }> }
+) => {
+    const apiKey =
+        req.headers.get("x-nxopen-api-key") || process.env.VITE_NEXON_API_KEY;
+
+    const handler = GetWithParams<
+        { endpoint: string } & Record<string, string>
+    >(async (params) => {
+        if (!apiKey) return Failed("Missing API Key", 500);
+
+        const { endpoint, ...query } = params;
+
+        try {
+            const res = await axios.get(
+                `https://open.api.nexon.com/maplestory/v1/auction/${endpoint}`,
+                {
+                    params: query,
+                    headers: { "x-nxopen-api-key": apiKey },
+                }
+            );
+            return Success("옥션 정보 조회 성공", 200, { data: res.data });
+        } catch (err: unknown) {
+            if (err instanceof AxiosError) {
+                const message =
+                    err.response?.data?.error?.message ?? err.message;
+                const status = err.response?.status ?? 500;
+                return Failed(message, status);
+            }
+            if (err instanceof Error) return Failed(err.message, 500);
+            return Failed("Unknown error", 500);
+        }
+    });
+
+    return handler(req, context);
+};

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -50,6 +50,15 @@ const SideMenu = () => {
                         <Button
                             variant="ghost"
                             className="w-full"
+                            onClick={() => router.push("/auction")}
+                        >
+                            Auction
+                        </Button>
+                    </SheetClose>
+                    <SheetClose asChild>
+                        <Button
+                            variant="ghost"
+                            className="w-full"
                             onClick={() => router.push("/my_page")}
                         >
                             My Page

--- a/src/components/auction/AuctionList.tsx
+++ b/src/components/auction/AuctionList.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { findAuctionList } from "@/fetchs/auction.fetch";
+
+const AuctionList = () => {
+    const [data, setData] = useState<unknown>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const load = async () => {
+            try {
+                const res = await findAuctionList("환생의불꽃");
+                setData(res.data);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : String(err));
+            }
+        };
+        load();
+    }, []);
+
+    if (error) return <div>Error: {error}</div>;
+
+    return (
+        <div>
+            <h1 className="text-xl font-bold mb-4">Auction</h1>
+            {data ? (
+                <pre className="text-xs whitespace-pre-wrap">{JSON.stringify(data, null, 2)}</pre>
+            ) : (
+                <div>Loading...</div>
+            )}
+        </div>
+    );
+};
+
+export default AuctionList;

--- a/src/fetchs/auction.fetch.ts
+++ b/src/fetchs/auction.fetch.ts
@@ -1,0 +1,44 @@
+import axios, { AxiosError } from "axios";
+import { IAuctionList } from "@/interface/auction/IAuction";
+import { IAuctionResponse } from "@/interface/auction/IAuctionResponse";
+import { userStore } from "@/stores/userStore";
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+let requestQueue: Promise<unknown> = Promise.resolve();
+
+const callAuctionApi = async <T>(
+    endpoint: string,
+    params: Record<string, string | number | undefined> = {}
+): Promise<IAuctionResponse<T>> => {
+    const apiKey = userStore.getState().user.apiKey;
+
+    const task = async () => {
+        await delay(200);
+        try {
+            const response = await axios.get<IAuctionResponse<T>>(`/api/auction/${endpoint}`,
+                {
+                    headers: { "x-nxopen-api-key": apiKey ?? "" },
+                    params: Object.fromEntries(
+                        Object.entries(params).filter(([, v]) => v !== undefined)
+                    ),
+                }
+            );
+            return response.data;
+        } catch (err) {
+            if (err instanceof AxiosError && err.response?.data?.error?.message === "Missing API Key") {
+                if (typeof window !== "undefined") {
+                    window.location.href = "/my_page?missingApiKey=1";
+                }
+            }
+            throw err;
+        }
+    };
+
+    const result = requestQueue.then(task);
+    requestQueue = result.catch(() => undefined);
+    return result;
+};
+
+export const findAuctionList = (item_name: string, page?: number) =>
+    callAuctionApi<IAuctionList>("list", { item_name, page });

--- a/src/interface/auction/IAuction.ts
+++ b/src/interface/auction/IAuction.ts
@@ -1,0 +1,12 @@
+export interface IAuctionItem {
+    item_name: string;
+    unit_price: number;
+    quantity: number;
+    [key: string]: unknown;
+}
+
+export interface IAuctionList {
+    count: number;
+    items: IAuctionItem[];
+    [key: string]: unknown;
+}

--- a/src/interface/auction/IAuctionResponse.ts
+++ b/src/interface/auction/IAuctionResponse.ts
@@ -1,0 +1,5 @@
+export interface IAuctionResponse<T> {
+    message: string;
+    status: number;
+    data: T;
+}


### PR DESCRIPTION
## Summary
- add auction page that fetches Nexon auction data
- expose auction API proxy and client fetch helper
- link auction page from side menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c7cd9cef70832490f719427504a61e