### PR TITLE
Display union and dojang info in character banner

### DIFF
--- a/src/app/api/guild/[endpoint]/route.ts
+++ b/src/app/api/guild/[endpoint]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from "next/server";
+import axios, { AxiosError } from "axios";
+import { GetWithParams } from "@/utils/fetch";
+import { Failed, Success } from "@/utils/message";
+
+export const GET = async (
+    req: NextRequest,
+    context: { params: Promise<{ endpoint: string }> }
+) => {
+    const apiKey =
+        req.headers.get("x-nxopen-api-key") || process.env.VITE_NEXON_API_KEY;
+
+    const handler = GetWithParams<
+        { endpoint: string } & Record<string, string>
+    >(async (params) => {
+        if (!apiKey) return Failed("Missing API Key", 500);
+
+        const { endpoint, ...query } = params;
+
+        try {
+            const res = await axios.get(
+                `https://open.api.nexon.com/maplestory/v1/guild/${endpoint}`,
+                {
+                    params: query,
+                    headers: { "x-nxopen-api-key": apiKey },
+                }
+            );
+            return Success("길드 정보 조회 성공", 200, { data: res.data });
+        } catch (err: unknown) {
+            if (err instanceof AxiosError) {
+                const message =
+                    err.response?.data?.error?.message ?? err.message;
+                const status = err.response?.status ?? 500;
+                return Failed(message, status);
+            }
+            if (err instanceof Error) return Failed(err.message, 500);
+            return Failed("Unknown error", 500);
+        }
+    });
+
+    return handler(req, context);
+};

--- a/src/components/character/CharacterBanner.tsx
+++ b/src/components/character/CharacterBanner.tsx
@@ -1,18 +1,23 @@
 "use client";
 
 import Image from "next/image";
-import { Skeleton } from "@/components/ui/skeleton";
-import { ICharacterBasic, ICharacterPopularity } from "@/interface/character/ICharacter";
 import WorldIcon from "@/components/common/WorldIcon";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ICharacterBasic, ICharacterPopularity, ICharacterDojang } from "@/interface/character/ICharacter";
+import { IGuildBasic } from "@/interface/guild/IGuild";
+import { IUnion } from "@/interface/union/IUnion";
 
 type CharacterBannerProps = {
     basic: ICharacterBasic | null
     popularity: ICharacterPopularity | null
+    union: IUnion | null
+    dojang: ICharacterDojang | null
+    guild: IGuildBasic | null
     loading: boolean
     imageScale: number
 }
 
-const CharacterBanner = ({ basic, popularity, loading, imageScale }: CharacterBannerProps) => (
+const CharacterBanner = ({ basic, popularity, union, dojang, guild, loading, imageScale }: CharacterBannerProps) => (
     <div className="relative h-60 sm:h-64 w-full rounded-none border-0 bg-card">
         {loading || !basic ? (
             <div className="absolute inset-0 animate-pulse">
@@ -26,6 +31,8 @@ const CharacterBanner = ({ basic, popularity, loading, imageScale }: CharacterBa
                     <Skeleton className="w-16 h-6" />
                 </div>
                 <div className="absolute bottom-12 left-2 space-y-2">
+                    <Skeleton className="w-32 h-6" />
+                    <Skeleton className="w-32 h-6" />
                     <Skeleton className="w-32 h-6" />
                     <Skeleton className="w-32 h-6" />
                     <Skeleton className="w-32 h-6" />
@@ -54,16 +61,20 @@ const CharacterBanner = ({ basic, popularity, loading, imageScale }: CharacterBa
                     {basic.character_class}
                 </div>
                 <div className="absolute bottom-12 left-2 space-y-2 text-sm">
-                    <div className="bg-muted px-3 py-1 rounded-md">{basic.world_name}</div>
-                    {basic.character_guild_name && (
-                        <div className="bg-muted px-3 py-1 rounded-md">
-                            {basic.character_guild_name}
-                        </div>
+                    {union && (
+                        <div className="bg-muted px-3 py-1 rounded-md">유니온 {union.union_level}</div>
+                    )}
+                    {dojang && (
+                        <div className="bg-muted px-3 py-1 rounded-md">무릉 {dojang.dojang_best_floor}층</div>
                     )}
                     {popularity && (
-                        <div className="bg-muted px-3 py-1 rounded-md">
-                            인기도 {popularity.popularity}
-                        </div>
+                        <div className="bg-muted px-3 py-1 rounded-md">인기도 {popularity.popularity}</div>
+                    )}
+                    {basic.character_guild_name && (
+                        <div className="bg-muted px-3 py-1 rounded-md">길드 {basic.character_guild_name}</div>
+                    )}
+                    {guild?.guild_alliance_name && (
+                        <div className="bg-muted px-3 py-1 rounded-md">연합 {guild.guild_alliance_name}</div>
                     )}
                 </div>
                 <div className="absolute bottom-12 right-2 bg-muted px-3 py-1 rounded-md text-sm">

--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -29,6 +29,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { findCharacterAbility, findCharacterAndroidEquipment, findCharacterBasic, findCharacterBeautyEquipment, findCharacterCashItemEquipment, findCharacterDojang, findCharacterHexaMatrix, findCharacterHexaMatrixStat, findCharacterHyperStat, findCharacterItemEquipment, findCharacterLinkSkill, findCharacterOtherStat, findCharacterPetEquipment, findCharacterPopularity, findCharacterPropensity, findCharacterRingExchange, findCharacterSetEffect, findCharacterSkill, findCharacterStat, findCharacterSymbolEquipment, findCharacterVMatrix, } from '@/fetchs/character.fetch';
+import { findGuildBasic, findGuildId } from '@/fetchs/guild.fetch';
 import { findUnion, findUnionArtifact, findUnionRaider } from '@/fetchs/union.fetch';
 import { characterDetailStore } from "@/stores/characterDetailStore";
 
@@ -38,8 +39,8 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         union, unionRaider, unionArtifact,
         itemEquip, cashEquip, symbolEquip, setEffect, skill, linkSkill,
         hexaMatrix, hexaStat, vMatrix, dojang, ring, otherStat,
-        beauty, android, pet, propensity, ability,
-        setBasic, setStat, setPopularity, setHyper,
+        beauty, android, pet, propensity, ability, guild,
+        setBasic, setStat, setPopularity, setHyper, setGuild,
         setUnion, setUnionRaider, setUnionArtifact,
         setItemEquip, setCashEquip, setSymbolEquip, setSetEffect, setSkill, setLinkSkill,
         setHexaMatrix, setHexaStat, setVMatrix, setDojang, setRing, setOtherStat,
@@ -60,18 +61,32 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         const load = async () => {
             setBasicLoading(true);
             try {
-                const [basicRes, statRes, popularityRes, hyperRes, abilityRes] = await Promise.all([
+                const [basicRes, statRes, popularityRes, hyperRes, abilityRes, unionRes, dojangRes] = await Promise.all([
                     findCharacterBasic(ocid),
                     findCharacterStat(ocid),
                     findCharacterPopularity(ocid),
                     findCharacterHyperStat(ocid),
                     findCharacterAbility(ocid),
+                    findUnion(ocid),
+                    findCharacterDojang(ocid),
                 ]);
                 setBasic(basicRes.data);
                 setStat(statRes.data);
                 setPopularity(popularityRes.data);
                 setHyper(hyperRes.data);
                 setAbility(abilityRes.data);
+                setUnion(unionRes.data);
+                setDojang(dojangRes.data);
+
+                if (basicRes.data.character_guild_name) {
+                    try {
+                        const guildIdRes = await findGuildId(basicRes.data.character_guild_name);
+                        const guildRes = await findGuildBasic(guildIdRes.data.oguild);
+                        setGuild(guildRes.data);
+                    } catch (e) {
+                        console.error(e);
+                    }
+                }
             } catch (e) {
                 console.error(e);
                 toast.error('캐릭터 정보 로딩 실패');
@@ -83,7 +98,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         reset();
         setTab("basic");
         load();
-    }, [ocid, reset, setBasic, setStat, setPopularity, setHyper, setAbility]);
+    }, [ocid, reset, setBasic, setStat, setPopularity, setHyper, setAbility, setUnion, setDojang, setGuild]);
 
     // 유니온 탭 로딩
     useEffect(() => {
@@ -266,6 +281,9 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                     <CharacterBanner
                         basic={basic}
                         popularity={popularity}
+                        union={union}
+                        dojang={dojang}
+                        guild={guild}
                         loading={basicLoading || !basic}
                         imageScale={imageScale}
                     />

--- a/src/fetchs/guild.fetch.ts
+++ b/src/fetchs/guild.fetch.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import { IGuildBasic, IGuildId } from '@/interface/guild/IGuild';
+import { IGuildResponse } from '@/interface/guild/IGuildResponse';
+
+const callGuildApi = async <T>(endpoint: string, params: Record<string, string>) => {
+    const response = await axios.get<IGuildResponse<T>>(`/api/guild/${endpoint}`, {
+        params,
+    });
+    return response.data;
+};
+
+export const findGuildId = (guild_name: string) =>
+    callGuildApi<IGuildId>('id', { guild_name });
+
+export const findGuildBasic = (oguild: string) =>
+    callGuildApi<IGuildBasic>('basic', { oguild });

--- a/src/interface/guild/IGuild.ts
+++ b/src/interface/guild/IGuild.ts
@@ -1,0 +1,10 @@
+export interface IGuildId {
+    oguild: string;
+}
+
+export interface IGuildBasic {
+    date: string;
+    world_name: string;
+    guild_name: string;
+    guild_alliance_name: string | null;
+}

--- a/src/interface/guild/IGuildResponse.ts
+++ b/src/interface/guild/IGuildResponse.ts
@@ -1,0 +1,5 @@
+export interface IGuildResponse<T> {
+    message: string;
+    status: number;
+    data: T;
+}

--- a/src/stores/characterDetailStore.ts
+++ b/src/stores/characterDetailStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { ICharacterAbility, ICharacterAndroidEquipment, ICharacterBasic, ICharacterBeautyEquipment, ICharacterCashItemEquipment, ICharacterDojang, ICharacterHexaMatrix, ICharacterHexaMatrixStat, ICharacterHyperStat, ICharacterItemEquipment, ICharacterLinkSkill, ICharacterOtherStat, ICharacterPetEquipment, ICharacterPopularity, ICharacterPropensity, ICharacterSetEffect, ICharacterSkill, ICharacterStat, ICharacterSymbolEquipment, ICharacterVMatrix, IRingExchangeSkillEquipment, } from "@/interface/character/ICharacter";
+import { IGuildBasic } from "@/interface/guild/IGuild";
 import { IUnion, IUnionArtifact, IUnionChampion, IUnionRaider } from "@/interface/union/IUnion";
 
 type CharacterDetailSlice = {
@@ -9,6 +10,7 @@ type CharacterDetailSlice = {
     stat: ICharacterStat | null
     popularity: ICharacterPopularity | null
     hyper: ICharacterHyperStat | null
+    guild: IGuildBasic | null
 
     // 유니온
     union: IUnion | null
@@ -44,6 +46,7 @@ type CharacterDetailSlice = {
     setStat: (stat: CharacterDetailSlice['stat']) => void
     setPopularity: (popularity: CharacterDetailSlice['popularity']) => void
     setHyper: (hyper: CharacterDetailSlice['hyper']) => void
+    setGuild: (guild: CharacterDetailSlice['guild']) => void
     setUnion: (union: CharacterDetailSlice['union']) => void
     setUnionRaider: (unionRaider: CharacterDetailSlice['unionRaider']) => void
     setUnionArtifact: (unionArtifact: CharacterDetailSlice['unionArtifact']) => void
@@ -76,6 +79,7 @@ const initialState: Omit<
     | 'setStat'
     | 'setPopularity'
     | 'setHyper'
+    | 'setGuild'
     | 'setItemEquip'
     | 'setCashEquip'
     | 'setSymbolEquip'
@@ -103,6 +107,7 @@ const initialState: Omit<
     stat: null,
     popularity: null,
     hyper: null,
+    guild: null,
 
     union: null,
     unionRaider: null,
@@ -139,6 +144,7 @@ export const characterDetailStore = create<CharacterDetailSlice>()(
             setStat: (stat) => set({ stat }),
             setPopularity: (popularity) => set({ popularity }),
             setHyper: (hyper) => set({ hyper }),
+            setGuild: (guild) => set({ guild }),
             setUnion: (union) => set({ union }),
             setUnionRaider: (unionRaider) => set({ unionRaider }),
             setUnionArtifact: (unionArtifact) => set({ unionArtifact }),


### PR DESCRIPTION
## Summary
- load guild, union, and dojang info when fetching character basics
- add guild API and fetch helpers
- display union level, dojang floor, popularity, guild, and alliance on the character banner

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c7fd7774348324ab23c001cd753691