### PR TITLE
Return 401 for missing API key

### DIFF
--- a/src/app/api/character/[endpoint]/route.ts
+++ b/src/app/api/character/[endpoint]/route.ts
@@ -13,7 +13,7 @@ export const GET = async (
     const handler = GetWithParams<
         { endpoint: string } & Record<string, string>
     >(async (params) => {
-        if (!apiKey) return Failed("Missing API Key", 500);
+        if (!apiKey) return Failed("Missing API Key", 401);
 
         const { endpoint, ...query } = params;
 

--- a/src/app/api/character/list/route.ts
+++ b/src/app/api/character/list/route.ts
@@ -15,7 +15,7 @@ export const GET = async (req: Request) => {
         req.headers.get("x-nxopen-api-key") || process.env.VITE_NEXON_API_KEY;
 
     const handler = Get(async () => {
-        if (!apiKey) return Failed("Missing API Key", 500);
+        if (!apiKey) return Failed("Missing API Key", 401);
 
         try {
             const res = await axios.get<ICharacterListApiResponse>(

--- a/src/app/api/guild/[endpoint]/route.ts
+++ b/src/app/api/guild/[endpoint]/route.ts
@@ -13,7 +13,7 @@ export const GET = async (
     const handler = GetWithParams<
         { endpoint: string } & Record<string, string>
     >(async (params) => {
-        if (!apiKey) return Failed("Missing API Key", 500);
+        if (!apiKey) return Failed("Missing API Key", 401);
 
         const { endpoint, ...query } = params;
 

--- a/src/app/api/union/[endpoint]/route.ts
+++ b/src/app/api/union/[endpoint]/route.ts
@@ -13,7 +13,7 @@ export const GET = async (
     const handler = GetWithParams<
         { endpoint: string } & Record<string, string>
     >(async (params) => {
-        if (!apiKey) return Failed("Missing API Key", 500);
+        if (!apiKey) return Failed("Missing API Key", 401);
 
         const { endpoint, ...query } = params;
 


### PR DESCRIPTION
## Summary
- fix incorrect 500 responses for missing API key in character, guild, and union API routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ff8109248324987787ed34295a90