### PR TITLE
Add guild API interfaces and fetch

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -28,9 +28,31 @@ import ItemEquipments from "@/components/character/item/ItemEquipments";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { findCharacterAbility, findCharacterAndroidEquipment, findCharacterBasic, findCharacterBeautyEquipment, findCharacterCashItemEquipment, findCharacterDojang, findCharacterHexaMatrix, findCharacterHexaMatrixStat, findCharacterHyperStat, findCharacterItemEquipment, findCharacterLinkSkill, findCharacterOtherStat, findCharacterPetEquipment, findCharacterPopularity, findCharacterPropensity, findCharacterRingExchange, findCharacterSetEffect, findCharacterSkill, findCharacterStat, findCharacterSymbolEquipment, findCharacterVMatrix, } from '@/fetchs/character.fetch';
-import { findGuildBasic, findGuildId } from '@/fetchs/guild.fetch';
-import { findUnion, findUnionArtifact, findUnionRaider } from '@/fetchs/union.fetch';
+import {
+    findCharacterAbility,
+    findCharacterAndroidEquipment,
+    findCharacterBasic,
+    findCharacterBeautyEquipment,
+    findCharacterCashItemEquipment,
+    findCharacterDojang,
+    findCharacterHexaMatrix,
+    findCharacterHexaMatrixStat,
+    findCharacterHyperStat,
+    findCharacterItemEquipment,
+    findCharacterLinkSkill,
+    findCharacterOtherStat,
+    findCharacterPetEquipment,
+    findCharacterPopularity,
+    findCharacterPropensity,
+    findCharacterRingExchange,
+    findCharacterSetEffect,
+    findCharacterSkill,
+    findCharacterStat,
+    findCharacterSymbolEquipment,
+    findCharacterVMatrix,
+} from "@/fetchs/character.fetch";
+import { findGuildBasic, findGuildId } from "@/fetchs/guild.fetch";
+import { findUnion, findUnionArtifact, findUnionRaider } from "@/fetchs/union.fetch";
 import { characterDetailStore } from "@/stores/characterDetailStore";
 
 const CharacterDetail = ({ ocid }: { ocid: string }) => {
@@ -80,8 +102,13 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
 
                 if (basicRes.data.character_guild_name) {
                     try {
-                        const guildIdRes = await findGuildId(basicRes.data.character_guild_name);
-                        const guildRes = await findGuildBasic(guildIdRes.data.oguild);
+                        const guildIdRes = await findGuildId(
+                            basicRes.data.character_guild_name,
+                            basicRes.data.world_name,
+                        );
+                        const guildRes = await findGuildBasic(
+                            guildIdRes.data.oguild_id,
+                        );
                         setGuild(guildRes.data);
                     } catch (e) {
                         console.error(e);

--- a/src/fetchs/guild.fetch.ts
+++ b/src/fetchs/guild.fetch.ts
@@ -1,16 +1,51 @@
-import axios from 'axios';
-import { IGuildBasic, IGuildId } from '@/interface/guild/IGuild';
-import { IGuildResponse } from '@/interface/guild/IGuildResponse';
+import axios, { AxiosError } from "axios";
+import { IGuildBasic, IGuildId } from "@/interface/guild/IGuild";
+import { IGuildResponse } from "@/interface/guild/IGuildResponse";
+import { userStore } from "@/stores/userStore";
 
-const callGuildApi = async <T>(endpoint: string, params: Record<string, string>) => {
-    const response = await axios.get<IGuildResponse<T>>(`/api/guild/${endpoint}`, {
-        params,
-    });
-    return response.data;
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+let requestQueue: Promise<unknown> = Promise.resolve();
+
+const callGuildApi = async <T>(
+    endpoint: string,
+    params: Record<string, string | number | undefined> = {}
+): Promise<IGuildResponse<T>> => {
+    const apiKey = userStore.getState().user.apiKey;
+
+    const task = async () => {
+        await delay(200);
+        try {
+            const response = await axios.get<IGuildResponse<T>>(
+                `/api/guild/${endpoint}`,
+                {
+                    headers: { "x-nxopen-api-key": apiKey ?? "" },
+                    params: Object.fromEntries(
+                        Object.entries(params).filter(([, v]) => v !== undefined)
+                    ),
+                }
+            );
+            return response.data;
+        } catch (err) {
+            if (
+                err instanceof AxiosError &&
+                err.response?.data?.error?.message === "Missing API Key"
+            ) {
+                if (typeof window !== "undefined") {
+                    window.location.href = "/my_page?missingApiKey=1";
+                }
+            }
+            throw err;
+        }
+    };
+
+    const result = requestQueue.then(task);
+    requestQueue = result.catch(() => undefined);
+    return result;
 };
 
-export const findGuildId = (guild_name: string) =>
-    callGuildApi<IGuildId>('id', { guild_name });
+export const findGuildId = (guild_name: string, world_name: string) =>
+    callGuildApi<IGuildId>("id", { guild_name, world_name });
 
-export const findGuildBasic = (oguild: string) =>
-    callGuildApi<IGuildBasic>('basic', { oguild });
+export const findGuildBasic = (oguild_id: string, date?: string) =>
+    callGuildApi<IGuildBasic>("basic", { oguild_id, date });

--- a/src/interface/guild/IGuild.ts
+++ b/src/interface/guild/IGuild.ts
@@ -1,10 +1,25 @@
 export interface IGuildId {
-    oguild: string;
+    oguild_id: string;
+}
+
+export interface IGuildSkill {
+    skill_name: string;
+    skill_description: string;
+    skill_level: number;
+    skill_effect: string;
+    skill_icon: string;
 }
 
 export interface IGuildBasic {
     date: string;
     world_name: string;
     guild_name: string;
-    guild_alliance_name: string | null;
+    guild_level: number;
+    guild_fame: number;
+    guild_point: number;
+    guild_master_name: string;
+    guild_member_count: number;
+    guild_member: string[];
+    guild_skill: IGuildSkill[];
+    guild_noblesse_skill: IGuildSkill[];
 }


### PR DESCRIPTION
## Summary
- define detailed guild response interfaces
- implement guild fetch functions with API key and throttle
- use new guild API in character details

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80186708083248fc9d8a24d893c4d