### PR TITLE
Use local Maplestory font instead of Google fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) with local fonts from the [`public/font`](./public/font) directory.
 
 ## Learn More
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import { Geist, Geist_Mono } from "next/font/google";
 import localFont from "next/font/local";
 import { type ReactNode, unstable_ViewTransition as ViewTransition } from "react";
 import type { Metadata } from "next";
@@ -21,16 +20,6 @@ const mapleStory = localFont({
     variable: "--font-maplestory",
 });
 
-const geistSans = Geist({
-    variable: "--font-geist-sans",
-    subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-    variable: "--font-geist-mono",
-    subsets: ["latin"],
-});
-
 export const metadata: Metadata = {
     title: "Finder",
     description: "MapleStory Finder",
@@ -42,9 +31,7 @@ export const metadata: Metadata = {
 const RootLayout = ({ children }: Readonly<{ children: ReactNode }>) => {
     return (
         <html lang="en" suppressHydrationWarning>
-            <body
-                className={`${geistSans.variable} ${geistMono.variable} ${mapleStory.variable} antialiased`}
-            >
+            <body className={`${mapleStory.className} ${mapleStory.variable} antialiased`}>
                 <script
                     dangerouslySetInnerHTML={{
                         __html: `(() => { try { const t = localStorage.getItem('theme'); if (t === 'dark') { document.documentElement.classList.add('dark'); } } catch (e) {} })();`,


### PR DESCRIPTION
## Summary
- remove Google font imports
- load Maplestory font from `public/font`
- document use of local fonts

## Testing
- `npm test` (missing script)
- `npm run lint`
- `npm run build` (fails: supabaseUrl is required)


------
https://chatgpt.com/codex/tasks/task_e_68c8023bb1848324ab5fc2ed3fe73e2b