### PR TITLE
feat: show server info on character cards

### DIFF
--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { Star } from "lucide-react";
+import WorldIcon from "@/components/common/WorldIcon";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
@@ -24,6 +25,14 @@ const CharacterCard = ({
             className={`p-4 flex flex-col relative w-full ${onSelect ? "cursor-pointer" : ""}`}
             onClick={onSelect}
         >
+            {/* 서버 정보 */}
+            <div className="absolute top-2 left-2 z-10 flex items-center gap-1">
+                <WorldIcon name={character.world_name} />
+                <span className="text-xs sm:text-sm md:text-base">
+                    {character.world_name}
+                </span>
+            </div>
+
             {/* 즐겨찾기 버튼 */}
             <div className="absolute top-2 right-2 z-10">
                 <Button

--- a/src/components/character/CharacterCardSkeleton.tsx
+++ b/src/components/character/CharacterCardSkeleton.tsx
@@ -3,7 +3,13 @@
 import { Card } from '@/components/ui/card';
 
 const CharacterCardSkeleton = () => (
-    <Card className="p-4 flex flex-col w-full">
+    <Card className="p-4 flex flex-col w-full relative">
+        {/* 서버 정보 Skeleton */}
+        <div className="absolute top-2 left-2 flex items-center gap-1">
+            <div className="w-5 h-5 bg-muted animate-pulse rounded-full" />
+            <div className="h-3 w-16 bg-muted animate-pulse rounded" />
+        </div>
+
         {/* 캐릭터 이미지 Skeleton (비율 고정) */}
         <div className="relative w-full aspect-[4/3] mb-4 bg-muted animate-pulse rounded-md" />
 


### PR DESCRIPTION
## Summary
- show server icon and world name on character cards
- align skeleton layout for server info

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c809bb5d188324b27aabcc486f72ab