### PR TITLE
refactor: reduce redundant data fetching

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -133,11 +133,11 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         const loadUnion = async () => {
             try {
                 const [unionRes, raiderRes, artifactRes] = await Promise.all([
-                    findUnion(ocid),
+                    union ? Promise.resolve(null) : findUnion(ocid),
                     findUnionRaider(ocid),
                     findUnionArtifact(ocid),
                 ]);
-                setUnion(unionRes.data);
+                if (!union && unionRes) setUnion(unionRes.data);
                 setUnionRaider(raiderRes.data);
                 setUnionArtifact(artifactRes.data);
             } catch (e) {
@@ -243,17 +243,17 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         const loadEtc = async () => {
             try {
                 const [
-                    dojangRes,
                     ringRes,
                     otherStatRes,
                     propensityRes,
+                    dojangRes,
                 ] = await Promise.all([
-                    findCharacterDojang(ocid),
                     findCharacterRingExchange(ocid),
                     findCharacterOtherStat(ocid),
                     findCharacterPropensity(ocid),
+                    dojang ? Promise.resolve(null) : findCharacterDojang(ocid),
                 ]);
-                setDojang(dojangRes.data);
+                if (!dojang && dojangRes) setDojang(dojangRes.data);
                 setRing(ringRes.data);
                 setOtherStat(otherStatRes.data);
                 setPropensity(propensityRes.data);
@@ -300,7 +300,6 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         viewport.addEventListener('scroll', handleScroll);
         return () => viewport.removeEventListener('scroll', handleScroll);
     }, [basicLoading]);
-console.log(basic, guild)
     return (
         <ViewTransition enter="fade" exit="fade">
             <ScrollArea id="character-detail-scroll" className="h-page">

--- a/src/stores/characterListStore.ts
+++ b/src/stores/characterListStore.ts
@@ -27,16 +27,24 @@ export const characterListStore = create<CharacterListSlice>()(persist((set) => 
                 const sorted = basicList.sort((a, b) => b.character_level - a.character_level);
                 set({ characters: sorted, loading: false });
 
-                await Promise.all(
+                const images = await Promise.all(
                     sorted.map(async (char) => {
                         const data = await findCharacterBasic(char.ocid);
-                        set((state) => ({
-                            characters: state.characters.map((c) =>
-                                c.ocid === char.ocid ? { ...c, image: data.data.character_image } : c
-                            ),
-                        }));
+                        return { ocid: char.ocid, image: data.data.character_image };
                     })
                 );
+
+                const imageMap = new Map<string, string>(
+                    images.map(({ ocid, image }) => [ocid, image])
+                );
+
+                set((state) => ({
+                    characters: state.characters.map((c) =>
+                        imageMap.has(c.ocid)
+                            ? { ...c, image: imageMap.get(c.ocid) }
+                            : c
+                    ),
+                }));
             } catch (err) {
                 set({ loading: false });
                 throw err;


### PR DESCRIPTION
## Summary
- avoid duplicate union and dojang API calls in character detail view
- batch character image updates to minimize store recalculations

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c82bb0aeb08324854f7a8d4ffd35f3