### PR TITLE
Fix mobile tab layout on small screens

### DIFF
--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -332,7 +332,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                             </Tabs>
 
                             {/* 오른쪽: 캐릭터 요약 */}
-                            <div className="flex items-center font-bold">
+                            <div className="hidden sm:flex items-center font-bold">
                                 {basic.character_image && (
                                     <Image
                                         src={`/api/crop?url=${encodeURIComponent(

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ const TabsList = ({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "bg-muted text-muted-foreground flex h-9 w-full max-w-full items-center justify-start rounded-lg p-[3px] overflow-x-auto sm:w-fit sm:justify-center sm:overflow-visible data-[orientation=vertical]:flex-col",
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ const TabsTrigger = ({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-shrink-0 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm sm:flex-1 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- allow the tab list to scroll horizontally and fill the container on narrow viewports while preserving the desktop layout
- hide the sticky character summary in the header on small screens to prevent it from crowding the tabs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c85537b6f483249a67d0be4458df74