### PR TITLE
docs: refresh README for GitHub presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,72 @@
 # MapleStory Finder
 
-<img src="./public/Reheln.png" width="120" alt="Finder logo" />
+<p align="center">
+  <img src="./public/Reheln.png" width="140" alt="Finder logo" />
+</p>
 
-[![Next.js](https://img.shields.io/badge/Next.js-000?logo=nextdotjs&logoColor=fff)](https://nextjs.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
-[![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-38B2AC?logo=tailwindcss&logoColor=fff)](https://tailwindcss.com/)
-[![Supabase](https://img.shields.io/badge/Supabase-3ecf8e?logo=supabase&logoColor=000)](https://supabase.com/)
+<p align="center">
+  MapleStory 캐릭터를 빠르게 탐색하고 즐겨찾기로 관리할 수 있는 Next.js 기반 대시보드입니다.
+</p>
 
-Finder is a Next.js application for exploring MapleStory character information using the official Nexon Open API. Search for characters, manage favourites and view detailed stats with a fast, responsive interface.
+<p align="center">
+  <a href="https://nextjs.org/"><img src="https://img.shields.io/badge/Next.js-000?logo=nextdotjs&logoColor=fff" alt="Next.js" /></a>
+  <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=fff" alt="TypeScript" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwind_CSS-38B2AC?logo=tailwindcss&logoColor=fff" alt="Tailwind" /></a>
+  <a href="https://supabase.com/"><img src="https://img.shields.io/badge/Supabase-3ecf8e?logo=supabase&logoColor=000" alt="Supabase" /></a>
+</p>
 
-## Features
-- 🔍 Search MapleStory characters by name or OCID
-- ⭐ Save favourite characters and access them quickly
-- 📊 Detailed character stats with responsive UI
-- 🔒 Supabase authentication for secure data storage
-- 🌙 Dark‑mode friendly design
+---
+
+## Table of Contents
+- [Overview](#overview)
+- [Key Features](#key-features)
+- [Tech Stack](#tech-stack)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Environment Variables](#environment-variables)
+  - [Available Scripts](#available-scripts)
+- [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+
+## Overview
+MapleStory Finder는 Nexon Open API를 활용해 게임 내 캐릭터 정보를 검색하고, 즐겨찾기 및 상세 스탯을 한 화면에서 확인할 수 있는 웹 애플리케이션입니다. 최신 Next.js 15와 React 19를 사용해 빠른 응답성과 부드러운 사용자 경험을 제공합니다.
+
+## Key Features
+- 🔍 **캐릭터 검색**: 이름 또는 OCID로 MapleStory 캐릭터를 즉시 찾을 수 있습니다.
+- ⭐ **즐겨찾기 보관함**: 자주 확인하는 캐릭터를 저장하고 한 번에 접근합니다.
+- 📊 **상세 스탯 시각화**: 장비, 능력치 등 다양한 정보를 그래프로 확인합니다.
+- 🔒 **안전한 인증**: Supabase 인증을 통해 즐겨찾기 데이터를 안전하게 보관합니다.
+- 🌙 **다크 모드 최적화**: Tailwind CSS 4 기반의 반응형 UI로 어디서나 편안하게 탐색합니다.
 
 ## Tech Stack
-- **Next.js 15** & **React 19**
-- **TypeScript**
-- **Tailwind CSS 4** & **Radix UI** components
-- **Supabase** for authentication & storage
-- Zustand, Recharts and other utilities
+| 카테고리 | 사용 기술 |
+| --- | --- |
+| 프레임워크 | Next.js 15, React 19 |
+| 언어 | TypeScript |
+| 스타일링 | Tailwind CSS 4, Radix UI |
+| 데이터 & 인증 | Supabase |
+| 상태 관리 & 유틸 | Zustand, Recharts, React Window 등 |
 
 ## Getting Started
+빠르게 개발 환경을 구성하는 방법을 안내합니다.
 
 ### Prerequisites
-- Node.js 18+
-- npm
+- Node.js 18 이상
+- npm (Node.js 설치 시 기본 포함)
 
 ### Installation
 ```bash
-# Clone the repository
- git clone <repo-url>
- cd MapleStory-Finder
+# 저장소 클론
+git clone <repo-url>
+cd MapleStory-Finder
 
-# Install dependencies
- npm install
+# 의존성 설치
+npm install
 ```
 
 ### Environment Variables
-Create a `.env.local` file in the project root and provide the following values:
+프로젝트 루트에 `.env.local` 파일을 생성하고 아래 값을 입력하세요.
 
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
@@ -48,25 +74,31 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 VITE_NEXON_API_KEY=your_nexon_open_api_key
 ```
 
-### Development
-Start the development server:
+> [!TIP]
+> Nexon Open API 키는 [공식 개발자 포털](https://openapi.nexon.com/)에서 발급받을 수 있습니다.
 
-```bash
-npm run dev
-```
-Visit <http://localhost:3000> to view the app.
+### Available Scripts
+개발 및 배포를 위한 npm 스크립트입니다.
 
-### Linting
-Run ESLint to check for issues:
-
-```bash
-npm run lint
-```
+| 명령어 | 설명 |
+| --- | --- |
+| `npm run dev` | Turbopack을 활용한 개발 서버 실행 (기본 포트: <http://localhost:3000>) |
+| `npm run build` | 프로덕션 빌드 생성 |
+| `npm run start` | 빌드된 앱을 프로덕션 모드로 실행 |
+| `npm run lint` | ESLint 검사 및 자동 수정 수행 |
 
 ## Contributing
-Contributions are welcome! Feel free to open issues and pull requests to help improve the project.
+기여를 환영합니다! 이슈 등록 또는 Pull Request를 통해 개선 사항을 공유해주세요.
+
+1. 작업용 브랜치를 생성합니다.
+2. 코드 및 문서 수정을 진행합니다.
+3. 테스트와 린트를 실행하고 결과를 확인합니다.
+4. Pull Request를 열어 변경 사항을 설명해주세요.
+
+## Acknowledgements
+- Nexon Open API를 제공해 주는 Nexon에 감사드립니다.
+- MapleStory 및 MapleStory 로고는 Nexon의 등록 상표입니다.
 
 ---
 
-*MapleStory and the MapleStory logo are trademarks of Nexon.*
-
+*본 프로젝트는 Nexon과 공식적인 제휴 관계가 없습니다.*


### PR DESCRIPTION
## Summary
- refresh the README with a centered hero section, badges, and table of contents for better GitHub Pages presentation
- expand documentation in Korean covering key features, tech stack, environment setup, and npm scripts

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c8be1555e48324aa0ad413fc482543