### PR TITLE
Add view transitions to chat and figure pages

### DIFF
--- a/src/app/(main)/chat/page.tsx
+++ b/src/app/(main)/chat/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { FormEvent, useEffect, useRef, useState } from "react";
+import {
+    FormEvent,
+    unstable_ViewTransition as ViewTransition,
+    useEffect,
+    useRef,
+    useState,
+} from "react";
 import { Bot, Loader2, Send, Trash2, User } from "lucide-react";
 import { buildPromptContext } from "@/libs/promptContext";
 import type { ChatHistoryMessage } from "@/types/ai/chat";
@@ -64,109 +70,111 @@ const ChatPage = () => {
     };
 
     return (
-        <div className="mx-auto flex h-full max-w-4xl flex-col">
-            <Card className="flex h-full flex-col">
-                <CardHeader className="border-b">
-                    <div className="flex items-start justify-between gap-4">
-                        <div>
-                            <CardTitle className="text-2xl font-bold">Gemini AI 챗봇</CardTitle>
-                            <CardDescription className="mt-2 space-y-1 text-sm text-muted-foreground">
-                                <p>메이플스토리 캐릭터, 길드, 장비 데이터를 활용해 질문에 답변합니다.</p>
-                            </CardDescription>
+        <ViewTransition enter="fade" exit="fade">
+            <div className="mx-auto flex h-full max-w-4xl flex-col">
+                <Card className="flex h-full flex-col">
+                    <CardHeader className="border-b">
+                        <div className="flex items-start justify-between gap-4">
+                            <div>
+                                <CardTitle className="text-2xl font-bold">Gemini AI 챗봇</CardTitle>
+                                <CardDescription className="mt-2 space-y-1 text-sm text-muted-foreground">
+                                    <p>메이플스토리 캐릭터, 길드, 장비 데이터를 활용해 질문에 답변합니다.</p>
+                                </CardDescription>
+                            </div>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                className="gap-2"
+                                onClick={() => {
+                                    clear();
+                                    setPendingContext(null);
+                                    setQuestion("");
+                                }}
+                                disabled={!messages.length || isLoading}
+                            >
+                                <Trash2 className="h-4 w-4"/> 초기화
+                            </Button>
                         </div>
-                        <Button
-                            type="button"
-                            variant="ghost"
-                            className="gap-2"
-                            onClick={() => {
-                                clear();
-                                setPendingContext(null);
-                                setQuestion("");
-                            }}
-                            disabled={!messages.length || isLoading}
-                        >
-                            <Trash2 className="h-4 w-4"/> 초기화
-                        </Button>
-                    </div>
-                </CardHeader>
-                <CardContent className="flex min-h-0 flex-1 flex-col gap-4 py-4">
-                    <ScrollArea className="h-full pr-2">
-                        <div className="flex flex-col gap-4">
-                            {messages.length === 0 && !isLoading ? (
-                                <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                                    첫 질문을 입력하면 Gemini AI가 관련 데이터를 수집해 답변을 제공합니다.
-                                </div>
-                            ) : null}
-                            {messages.map((message) => {
-                                const isUser = message.role === "user";
-                                return (
-                                    <div
-                                        key={message.id}
-                                        className={cn(
-                                            "flex w-full gap-3",
-                                            isUser ? "justify-end" : "justify-start",
-                                        )}
-                                    >
-                                        {!isUser && (
-                                            <div
-                                                className={cn(
-                                                    "w-10 h-10 flex items-center justify-center rounded-full bg-muted text-muted-foreground"
-                                                )}
-                                            >
-                                                <Bot className="h-4 w-4"/>
-                                            </div>
-                                        )}
+                    </CardHeader>
+                    <CardContent className="flex min-h-0 flex-1 flex-col gap-4 py-4">
+                        <ScrollArea className="h-full pr-2">
+                            <div className="flex flex-col gap-4">
+                                {messages.length === 0 && !isLoading ? (
+                                    <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                                        첫 질문을 입력하면 Gemini AI가 관련 데이터를 수집해 답변을 제공합니다.
+                                    </div>
+                                ) : null}
+                                {messages.map((message) => {
+                                    const isUser = message.role === "user";
+                                    return (
                                         <div
+                                            key={message.id}
                                             className={cn(
-                                                "max-w-[80%] rounded-2xl px-4 py-3 text-sm whitespace-pre-wrap",
-                                                isUser
-                                                    ? "bg-primary text-primary-foreground"
-                                                    : "bg-muted text-muted-foreground",
+                                                "flex w-full gap-3",
+                                                isUser ? "justify-end" : "justify-start",
                                             )}
                                         >
-                                            {message.content}
-                                        </div>
-                                        {isUser && (
-                                            <div className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">
-                                                <User className="h-4 w-4"/>
+                                            {!isUser && (
+                                                <div
+                                                    className={cn(
+                                                        "w-10 h-10 flex items-center justify-center rounded-full bg-muted text-muted-foreground"
+                                                    )}
+                                                >
+                                                    <Bot className="h-4 w-4"/>
+                                                </div>
+                                            )}
+                                            <div
+                                                className={cn(
+                                                    "max-w-[80%] rounded-2xl px-4 py-3 text-sm whitespace-pre-wrap",
+                                                    isUser
+                                                        ? "bg-primary text-primary-foreground"
+                                                        : "bg-muted text-muted-foreground",
+                                                )}
+                                            >
+                                                {message.content}
                                             </div>
-                                        )}
+                                            {isUser && (
+                                                <div className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">
+                                                    <User className="h-4 w-4"/>
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                                {isLoading ? (
+                                    <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                                        <Loader2 className="h-4 w-4 animate-spin"/>
+                                        <span>Gemini AI가 정보를 분석하고 있습니다...</span>
                                     </div>
-                                );
-                            })}
-                            {isLoading ? (
-                                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                                    <Loader2 className="h-4 w-4 animate-spin"/>
-                                    <span>Gemini AI가 정보를 분석하고 있습니다...</span>
-                                </div>
-                            ) : null}
-                            <div ref={bottomRef}/>
-                        </div>
-                    </ScrollArea>
-                    {pendingContext ? (
-                        <div className="rounded-lg bg-muted/50 p-3 text-xs text-muted-foreground">
-                            <p className="font-medium text-foreground">참고 데이터 요약</p>
-                            <pre className="mt-1 whitespace-pre-wrap font-sans text-xs leading-relaxed text-muted-foreground">
+                                ) : null}
+                                <div ref={bottomRef}/>
+                            </div>
+                        </ScrollArea>
+                        {pendingContext ? (
+                            <div className="rounded-lg bg-muted/50 p-3 text-xs text-muted-foreground">
+                                <p className="font-medium text-foreground">참고 데이터 요약</p>
+                                <pre className="mt-1 whitespace-pre-wrap font-sans text-xs leading-relaxed text-muted-foreground">
                                     {pendingContext}
                                 </pre>
-                        </div>
-                    ) : null}
-                </CardContent>
-                <CardFooter className="border-t">
-                    <form className="flex w-full items-center gap-3" onSubmit={handleSubmit}>
-                        <Input
-                            placeholder="질문을 입력하세요"
-                            value={question}
-                            onChange={(event) => setQuestion(event.target.value)}
-                            autoFocus
-                        />
-                        <Button type="submit" className="gap-2" disabled={isLoading || question.trim().length === 0}>
-                            <Send className="h-4 w-4"/>
-                        </Button>
-                    </form>
-                </CardFooter>
-            </Card>
-        </div>
+                            </div>
+                        ) : null}
+                    </CardContent>
+                    <CardFooter className="border-t">
+                        <form className="flex w-full items-center gap-3" onSubmit={handleSubmit}>
+                            <Input
+                                placeholder="질문을 입력하세요"
+                                value={question}
+                                onChange={(event) => setQuestion(event.target.value)}
+                                autoFocus
+                            />
+                            <Button type="submit" className="gap-2" disabled={isLoading || question.trim().length === 0}>
+                                <Send className="h-4 w-4"/>
+                            </Button>
+                        </form>
+                    </CardFooter>
+                </Card>
+            </div>
+        </ViewTransition>
     );
 };
 

--- a/src/app/(main)/figure/page.tsx
+++ b/src/app/(main)/figure/page.tsx
@@ -2,11 +2,18 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    unstable_ViewTransition as ViewTransition,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import { ArrowLeft, Loader2, RefreshCcw } from "lucide-react";
 import type { FigureGenerationMetadata, FigureResult } from "@/types/figure";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { requestCharacterFigure } from "@/fetchs/figure.fetch";
 import { characterDetailStore } from "@/stores/characterDetailStore";
 
@@ -90,130 +97,131 @@ const FigurePage = () => {
 
     if (!basic || !imageUrl) {
         return (
-            <div className="mx-auto flex h-full w-full max-w-3xl flex-col items-center justify-center gap-4 text-center">
-                <h1 className="text-2xl font-semibold">불러온 캐릭터가 없습니다.</h1>
-                <p className="text-sm text-muted-foreground">
-                    캐릭터 상세 페이지에서 피규어 버튼을 눌러야 현재 캐릭터 피규어를 생성할 수 있습니다.
-                </p>
-                <div className="flex gap-2">
-                    <Button onClick={() => router.push("/")}>메인으로</Button>
+            <ViewTransition enter="fade" exit="fade">
+                <div className="mx-auto flex h-full w-full max-w-3xl flex-col items-center justify-center gap-4 text-center">
+                    <h1 className="text-2xl font-semibold">불러온 캐릭터가 없습니다.</h1>
+                    <p className="text-sm text-muted-foreground">
+                        캐릭터 상세 페이지에서 피규어 버튼을 눌러야 현재 캐릭터 피규어를 생성할 수 있습니다.
+                    </p>
+                    <div className="flex gap-2">
+                        <Button onClick={() => router.push("/")}>메인으로</Button>
+                    </div>
                 </div>
-            </div>
+            </ViewTransition>
         );
     }
 
     return (
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-            <div className="flex items-center justify-between gap-3">
-                <div>
-                    <h1 className="text-2xl font-semibold">{basic.character_name} 피규어 생성</h1>
-                    <p className="text-sm text-muted-foreground">
-                        Google Gemini API를 이용해 캐릭터 이미지를 기반으로 피규어 렌더링을 생성합니다.
-                    </p>
-                </div>
-                <Button variant="ghost" onClick={handleBack} className="gap-2">
-                    <ArrowLeft className="h-4 w-4"/>
-                    돌아가기
-                </Button>
-            </div>
-
-            <Card>
-                <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <ViewTransition enter="fade" exit="fade">
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+                <div className="flex items-center justify-between gap-3">
                     <div>
-                        <CardTitle>피규어 생성 결과</CardTitle>
-                        <CardDescription>
-                            원본 캐릭터와 생성된 피규어 이미지를 비교해보세요. 필요하다면 다시 생성을 눌러 새로운 이미지를 받아볼 수 있습니다.
-                        </CardDescription>
+                        <h1 className="text-2xl font-semibold">{basic.character_name} 피규어 생성</h1>
+                        <p className="text-sm text-muted-foreground">
+                            Google Gemini API를 이용해 캐릭터 이미지를 기반으로 피규어 렌더링을 생성합니다.
+                        </p>
                     </div>
-                    <Button
-                        onClick={handleRegenerate}
-                        disabled={isGenerating}
-                        className="gap-2"
-                    >
-                        {isGenerating ? <Loader2 className="h-4 w-4 animate-spin"/> : <RefreshCcw className="h-4 w-4"/>}
-                        다시 생성
+                    <Button variant="ghost" onClick={handleBack} className="gap-2">
+                        <ArrowLeft className="h-4 w-4"/>
+                        돌아가기
                     </Button>
-                </CardHeader>
-                <CardContent>
-                    <div className="grid gap-8 md:grid-cols-2">
-                        <div className="space-y-4">
-                            <h2 className="text-lg font-semibold">원본 캐릭터</h2>
-                            <div className="rounded-lg border bg-muted/40 p-4">
-                                <div className="relative aspect-square w-full overflow-hidden rounded-md bg-background">
-                                    {croppedPreviewUrl ? (
-                                        <Image
-                                            src={croppedPreviewUrl}
-                                            alt={basic.character_name}
-                                            fill
-                                            className="object-contain"
-                                            priority
-                                            sizes="(min-width: 768px) 40vw, 100vw"
-                                            unoptimized
-                                        />
-                                    ) : (
-                                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                                            캐릭터 이미지를 불러오는 중입니다.
-                                        </div>
-                                    )}
-                                </div>
-                                <div className="mt-3 space-y-1 text-sm">
-                                    <p><span className="font-medium">직업</span>: {basic.character_class}</p>
-                                    <p><span className="font-medium">레벨</span>: {basic.character_level}</p>
-                                    {basic.world_name && (
-                                        <p><span className="font-medium">월드</span>: {basic.world_name}</p>
-                                    )}
+                </div>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>피규어 생성 결과</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="grid gap-8 md:grid-cols-2">
+                            <div className="space-y-4">
+                                <h2 className="text-lg font-semibold">원본 캐릭터</h2>
+                                <div className="rounded-lg border bg-muted/40 p-4">
+                                    <div className="relative aspect-square w-full overflow-hidden rounded-md bg-background">
+                                        {croppedPreviewUrl ? (
+                                            <Image
+                                                src={croppedPreviewUrl}
+                                                alt={basic.character_name}
+                                                fill
+                                                className="object-contain"
+                                                priority
+                                                sizes="(min-width: 768px) 40vw, 100vw"
+                                                unoptimized
+                                            />
+                                        ) : (
+                                            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                                                캐릭터 이미지를 불러오는 중입니다.
+                                            </div>
+                                        )}
+                                    </div>
+                                    <div className="mt-3 space-y-1 text-sm">
+                                        <p><span className="font-medium">직업</span>: {basic.character_class}</p>
+                                        <p><span className="font-medium">레벨</span>: {basic.character_level}</p>
+                                        {basic.world_name && (
+                                            <p><span className="font-medium">월드</span>: {basic.world_name}</p>
+                                        )}
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <div className="space-y-4">
-                            <h2 className="text-lg font-semibold">생성된 피규어</h2>
-                            <div className="rounded-lg border bg-muted/40 p-4">
-                                <div className="relative aspect-square w-full overflow-hidden rounded-md bg-background">
-                                    {figureSrc ? (
-                                        <Image
-                                            src={figureSrc}
-                                            alt={`${basic.character_name} figure`}
-                                            fill
-                                            className="object-contain"
-                                            sizes="(min-width: 768px) 40vw, 100vw"
-                                            unoptimized
-                                        />
-                                    ) : (
-                                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                                            {isGenerating ? (
-                                                <span className="flex items-center gap-2">
-                                                    <Loader2 className="h-4 w-4 animate-spin"/>
-                                                    피규어 이미지를 생성 중입니다...
-                                                </span>
-                                            ) : (
-                                                "생성된 이미지가 여기에 표시됩니다."
+                            <div className="space-y-4">
+                                <div className="flex flex-col items-stretch gap-3 md:flex-row md:items-center md:justify-between">
+                                    <h2 className="text-lg font-semibold">생성된 피규어</h2>
+                                    <Button
+                                        onClick={handleRegenerate}
+                                        disabled={isGenerating}
+                                        className="w-full gap-2 md:w-auto"
+                                    >
+                                        {isGenerating ? <Loader2 className="h-4 w-4 animate-spin"/> : <RefreshCcw className="h-4 w-4"/>}
+                                        다시 생성
+                                    </Button>
+                                </div>
+                                <div className="rounded-lg border bg-muted/40 p-4">
+                                    <div className="relative aspect-square w-full overflow-hidden rounded-md bg-background">
+                                        {figureSrc ? (
+                                            <Image
+                                                src={figureSrc}
+                                                alt={`${basic.character_name} figure`}
+                                                fill
+                                                className="object-contain"
+                                                sizes="(min-width: 768px) 40vw, 100vw"
+                                                unoptimized
+                                            />
+                                        ) : (
+                                            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                                                {isGenerating ? (
+                                                    <span className="flex items-center gap-2">
+                                                        <Loader2 className="h-4 w-4 animate-spin"/>
+                                                        피규어 이미지를 생성 중입니다...
+                                                    </span>
+                                                ) : (
+                                                    "생성된 이미지가 여기에 표시됩니다."
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                    {error ? (
+                                        <div className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                                            {error}
+                                        </div>
+                                    ) : null}
+                                    {metadata ? (
+                                        <div className="mt-3 text-xs text-muted-foreground">
+                                            {metadata.latencyMs !== undefined && (
+                                                <p>생성 시간: {(metadata.latencyMs / 1000).toFixed(2)}초</p>
                                             )}
+                                            {metadata.callId && (
+                                                <p>요청 ID: {metadata.callId}</p>
+                                            )}
+                                            {metadata.provider && <p>제공자: {metadata.provider}</p>}
+                                            {metadata.model && <p>모델: {metadata.model}</p>}
                                         </div>
-                                    )}
+                                    ) : null}
                                 </div>
-                                {error ? (
-                                    <div className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-                                        {error}
-                                    </div>
-                                ) : null}
-                                {metadata ? (
-                                    <div className="mt-3 text-xs text-muted-foreground">
-                                        {metadata.latencyMs !== undefined && (
-                                            <p>생성 시간: {(metadata.latencyMs / 1000).toFixed(2)}초</p>
-                                        )}
-                                        {metadata.callId && (
-                                            <p>요청 ID: {metadata.callId}</p>
-                                        )}
-                                        {metadata.provider && <p>제공자: {metadata.provider}</p>}
-                                        {metadata.model && <p>모델: {metadata.model}</p>}
-                                    </div>
-                                ) : null}
                             </div>
                         </div>
-                    </div>
-                </CardContent>
-            </Card>
-        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </ViewTransition>
     );
 };
 


### PR DESCRIPTION
## Summary
- enable fade view transitions on the chat and figure pages to match the rest of the app
- simplify the figure results header copy and reposition the regenerate button alongside the generated preview
- keep the figure layout responsive so controls no longer clip at smaller viewports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c91315256c83248995ddf6a09affe3