### PR TITLE
feat: unify page styling across app

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { supabase } from '@/libs/supabaseClient';
+import BackgroundPattern from '@/components/layouts/BackgroundPattern';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -84,76 +85,92 @@ const SignInPage = () => {
     };
 
     return (
-        <div className="flex min-h-screen">
-            <div className="relative hidden w-1/2 md:block">
-                <Image
-                    src="https://lwi.nexon.com/maplestory/common/media/artwork/artwork_117.jpg"
-                    alt="Cover"
-                    className="absolute inset-0 h-full w-full object-cover"
-                    fill
-                    priority
-                />
+        <BackgroundPattern>
+            <div className="flex flex-1 items-center justify-center px-4 py-10 sm:px-6 lg:px-8">
+                <div className="relative w-full max-w-lg">
+                    <div className="pointer-events-none absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-br from-primary/25 via-transparent to-primary/10 opacity-80 blur-3xl" />
+                    <div className="relative flex flex-col gap-8 overflow-hidden rounded-[32px] border border-border/60 bg-card/80 p-10 shadow-[0_40px_80px_-50px_rgba(15,23,42,0.55)] backdrop-blur-md sm:p-12">
+                        <div className="flex flex-col items-center gap-4 text-center">
+                            <span className="relative flex h-20 w-20 items-center justify-center rounded-3xl border border-border/60 bg-gradient-to-br from-primary/30 via-primary/20 to-primary/5 shadow-inner shadow-primary/20">
+                                <Image src="/Reheln.png" alt="Finder" width={56} height={56} priority className="drop-shadow-sm" />
+                            </span>
+                            <div className="space-y-2">
+                                <h1 className="text-3xl font-semibold tracking-tight">Finder에 다시 오신 것을 환영해요</h1>
+                                <p className="text-sm text-muted-foreground">
+                                    MapleStory 캐릭터를 빠르게 검색하고 즐겨찾기를 한곳에서 관리해보세요.
+                                </p>
+                            </div>
+                        </div>
+
+                        <form onSubmit={handleSubmit} className="space-y-5">
+                            <div className="space-y-2 text-left">
+                                <Label htmlFor="email">Email</Label>
+                                <Input
+                                    id="email"
+                                    type="email"
+                                    value={form.email}
+                                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                                    required
+                                    autoComplete="email"
+                                    className="h-12 rounded-full border-border/60 bg-background/80 px-5 text-base shadow-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-0"
+                                />
+                            </div>
+                            <div className="space-y-2 text-left">
+                                <Label htmlFor="password">Password</Label>
+                                <Input
+                                    id="password"
+                                    type="password"
+                                    value={form.password}
+                                    onChange={(e) => setForm({ ...form, password: e.target.value })}
+                                    required
+                                    autoComplete="current-password"
+                                    className="h-12 rounded-full border-border/60 bg-background/80 px-5 text-base shadow-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-0"
+                                />
+                            </div>
+                            <Button
+                                type="submit"
+                                className="h-12 w-full rounded-full text-base font-semibold shadow-[0_18px_40px_-24px_rgba(79,70,229,0.75)]"
+                                disabled={loading}
+                            >
+                                {loading ? 'Sign In...' : 'Sign In'}
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                className="h-12 w-full rounded-full border-border/60 bg-background/80 text-base font-semibold transition hover:border-primary/40"
+                                onClick={handleGoogle}
+                                disabled={googleLoading}
+                            >
+                                {googleLoading ? 'Sign in with Google...' : 'Sign in with Google'}
+                            </Button>
+
+                            <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                <span className="h-px w-full rounded-full bg-border" />
+                                <span>or</span>
+                                <span className="h-px w-full rounded-full bg-border" />
+                            </div>
+
+                            <Button
+                                type="button"
+                                variant="outline"
+                                className="h-12 w-full rounded-full border-dashed border-border/60 bg-background/70 text-base font-semibold hover:border-primary/40"
+                                onClick={handleGuestLogin}
+                                disabled={guestLoading}
+                            >
+                                {guestLoading ? '게스트로 입장 중...' : '게스트로 둘러보기'}
+                            </Button>
+                        </form>
+
+                        <p className="text-center text-sm text-muted-foreground">
+                            아직 계정이 없나요?{' '}
+                            <Link href="/sign_up" className="font-semibold text-primary underline-offset-4 hover:underline">
+                                Sign up
+                            </Link>
+                        </p>
+                    </div>
+                </div>
             </div>
-            <div className="flex flex-1 items-center justify-center p-4">
-                <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-                    <div className="space-y-2 text-center">
-                        <h1 className="text-2xl font-bold">Sign In</h1>
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="email">Email</Label>
-                        <Input
-                            id="email"
-                            type="email"
-                            value={form.email}
-                            onChange={(e) => setForm({ ...form, email: e.target.value })}
-                            required
-                        />
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="password">Password</Label>
-                        <Input
-                            id="password"
-                            type="password"
-                            value={form.password}
-                            onChange={(e) => setForm({ ...form, password: e.target.value })}
-                            required
-                        />
-                    </div>
-                    <Button type="submit" className="w-full" disabled={loading}>
-                        {loading ? 'Sign In...' : 'Sign In'}
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="outline"
-                        className="w-full"
-                        onClick={handleGoogle}
-                        disabled={googleLoading}
-                    >
-                        {googleLoading ? 'Sign in with Google...' : 'Sign in with Google'}
-                    </Button>
-                    <div className="relative flex items-center">
-                        <div className="flex-grow border-t border-gray-300" />
-                        <span className="mx-4 flex-shrink text-xs font-semibold tracking-wide text-muted-foreground">OR</span>
-                        <div className="flex-grow border-t border-gray-300" />
-                    </div>
-                    <Button
-                        type="button"
-                        variant="outline"
-                        className="w-full"
-                        onClick={handleGuestLogin}
-                        disabled={guestLoading}
-                    >
-                        {guestLoading ? '게스트로 입장 중...' : '게스트로 둘러보기'}
-                    </Button>
-                    <p className="text-sm text-center">
-                        Don&apos;t have an account?{' '}
-                        <Link href="/sign_up" className="underline">
-                            Sign up
-                        </Link>
-                    </p>
-                </form>
-            </div>
-        </div>
+        </BackgroundPattern>
     );
 };
 

--- a/src/app/(auth)/sign_up/page.tsx
+++ b/src/app/(auth)/sign_up/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { supabase } from '@/libs/supabaseClient';
+import BackgroundPattern from '@/components/layouts/BackgroundPattern';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -40,62 +41,92 @@ const SignUpPage = () => {
     };
 
     return (
-        <div className="flex min-h-screen">
-            <div className="relative hidden w-1/2 md:block">
-                <Image
-                    src="https://ssl.nexon.com/s2/game/maplestory/renewal/common/media/artwork/artwork_14.jpg"
-                    alt="Cover"
-                    className="absolute inset-0 h-full w-full object-cover"
-                    fill
-                    priority
-                />
+        <BackgroundPattern>
+            <div className="flex flex-1 items-center justify-center px-4 py-10 sm:px-6 lg:px-8">
+                <div className="relative w-full max-w-xl">
+                    <div className="pointer-events-none absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-br from-primary/25 via-transparent to-primary/10 opacity-80 blur-3xl" />
+                    <div className="relative flex flex-col gap-8 overflow-hidden rounded-[32px] border border-border/60 bg-card/80 p-10 shadow-[0_40px_80px_-50px_rgba(15,23,42,0.55)] backdrop-blur-md sm:p-12">
+                        <div className="flex flex-col items-center gap-4 text-center">
+                            <span className="relative flex h-20 w-20 items-center justify-center rounded-3xl border border-border/60 bg-gradient-to-br from-primary/30 via-primary/20 to-primary/5 shadow-inner shadow-primary/20">
+                                <Image src="/Reheln.png" alt="Finder" width={56} height={56} priority className="drop-shadow-sm" />
+                            </span>
+                            <div className="space-y-2">
+                                <h1 className="text-3xl font-semibold tracking-tight">Finder에 가입하고 시작해보세요</h1>
+                                <p className="text-sm text-muted-foreground">
+                                    Nexon API Key를 등록하면 즐겨찾기와 캐릭터 정보를 더 빠르게 불러올 수 있습니다.
+                                </p>
+                            </div>
+                        </div>
+
+                        <form onSubmit={handleSubmit} className="space-y-5">
+                            <div className="space-y-2 text-left">
+                                <Label htmlFor="email">Email</Label>
+                                <Input
+                                    id="email"
+                                    type="email"
+                                    value={form.email}
+                                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                                    required
+                                    autoComplete="email"
+                                    className="h-12 rounded-full border-border/60 bg-background/80 px-5 text-base shadow-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-0"
+                                />
+                            </div>
+                            <div className="space-y-2 text-left">
+                                <Label htmlFor="password">Password</Label>
+                                <Input
+                                    id="password"
+                                    type="password"
+                                    value={form.password}
+                                    onChange={(e) => setForm({ ...form, password: e.target.value })}
+                                    required
+                                    autoComplete="new-password"
+                                    className="h-12 rounded-full border-border/60 bg-background/80 px-5 text-base shadow-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-0"
+                                />
+                            </div>
+                            <div className="space-y-2 text-left">
+                                <div className="flex items-center justify-between">
+                                    <Label htmlFor="apiKey">Nexon API Key</Label>
+                                    <Link
+                                        href="https://openapi.nexon.com/"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-xs font-medium text-primary underline-offset-4 hover:underline"
+                                    >
+                                        발급 안내
+                                    </Link>
+                                </div>
+                                <Input
+                                    id="apiKey"
+                                    value={form.apiKey}
+                                    onChange={(e) => setForm({ ...form, apiKey: e.target.value })}
+                                    required
+                                    placeholder="예: NX-..."
+                                    className="h-12 rounded-full border-border/60 bg-background/80 px-5 text-base shadow-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-0"
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    입력한 키는 Supabase 계정 정보에 안전하게 저장되며, 언제든 내 정보에서 수정할 수 있습니다.
+                                </p>
+                            </div>
+
+                            <Button
+                                type="submit"
+                                className="h-12 w-full rounded-full text-base font-semibold shadow-[0_18px_40px_-24px_rgba(79,70,229,0.75)]"
+                                disabled={loading}
+                            >
+                                {loading ? 'Create account...' : 'Create account'}
+                            </Button>
+                        </form>
+
+                        <p className="text-center text-sm text-muted-foreground">
+                            이미 계정이 있으신가요?{' '}
+                            <Link href="/sign_in" className="font-semibold text-primary underline-offset-4 hover:underline">
+                                Sign in
+                            </Link>
+                        </p>
+                    </div>
+                </div>
             </div>
-            <div className="flex flex-1 items-center justify-center p-4">
-                <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-                    <div className="space-y-2 text-center">
-                        <h1 className="text-2xl font-bold">Sign Up</h1>
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="email">Email</Label>
-                        <Input
-                            id="email"
-                            type="email"
-                            value={form.email}
-                            onChange={(e) => setForm({ ...form, email: e.target.value })}
-                            required
-                        />
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="password">Password</Label>
-                        <Input
-                            id="password"
-                            type="password"
-                            value={form.password}
-                            onChange={(e) => setForm({ ...form, password: e.target.value })}
-                            required
-                        />
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="apiKey">Nexon API Key</Label>
-                        <Input
-                            id="apiKey"
-                            value={form.apiKey}
-                            onChange={(e) => setForm({ ...form, apiKey: e.target.value })}
-                            required
-                        />
-                    </div>
-                    <Button type="submit" className="w-full" disabled={loading}>
-                        {loading ? 'Create account...' : 'Create account'}
-                    </Button>
-                    <p className="text-sm text-center">
-                        Already have an account?{' '}
-                        <Link href="/sign_in" className="underline">
-                            Sign in
-                        </Link>
-                    </p>
-                </form>
-            </div>
-        </div>
+        </BackgroundPattern>
     );
 };
 

--- a/src/app/(main)/search/page.tsx
+++ b/src/app/(main)/search/page.tsx
@@ -33,7 +33,7 @@ const SearchPage = () => {
             router.push(`/character/${ocid}`);
         } catch (error) {
             let message = '캐릭터를 찾을 수 없습니다. 이름을 확인해주세요.';
-             if (error instanceof Error) {
+            if (error instanceof Error) {
                 message = error.message;
             }
             toast.error(message);
@@ -43,44 +43,51 @@ const SearchPage = () => {
     };
 
     return (
-        <div className="flex h-5/6 flex-col items-center justify-center px-4">
-            <div className="flex w-full max-w-2xl flex-col items-center gap-8">
-                <div className="flex flex-col items-center gap-3 text-center">
-                    <Image src="/Reheln.png" alt="Finder" width={96} height={96} priority />
-                    <h1 className="text-3xl font-semibold tracking-tight">Search</h1>
-                    <p className="max-w-lg text-balance text-sm text-muted-foreground">
-                        원하는 캐릭터를 찾아 상세 정보를 확인할 수 있습니다.
-                    </p>
+        <div className="flex h-full flex-col">
+            <div className="flex flex-1 items-center justify-center px-4">
+                <div className="flex w-full max-w-2xl flex-col items-center gap-10 text-center">
+                    <div className="flex flex-col items-center gap-4">
+                        <span className="relative flex h-24 w-24 items-center justify-center rounded-[28px] border border-border/60 bg-gradient-to-br from-primary/25 via-primary/15 to-primary/5 shadow-inner shadow-primary/20">
+                            <Image src="/Reheln.png" alt="Finder" width={96} height={96} priority className="drop-shadow-sm" />
+                        </span>
+                        <div className="space-y-2">
+                            <h1 className="text-3xl font-semibold tracking-tight">어떤 캐릭터를 찾으시나요?</h1>
+                            <p className="text-sm text-muted-foreground">
+                                Finder 검색에서 캐릭터 이름을 입력하면 상세 정보와 성장 기록을 빠르게 확인할 수 있어요.
+                            </p>
+                        </div>
+                    </div>
+
+                    <form onSubmit={handleSearch} className="w-full space-y-6">
+                        <div className="flex flex-col gap-3 rounded-full border border-border/60 bg-background/80 px-6 py-4 text-left shadow-sm transition focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/20 sm:flex-row sm:items-center">
+                            <SearchIcon className="h-5 w-5 flex-shrink-0 text-muted-foreground" aria-hidden="true" />
+                            <Input
+                                value={query}
+                                onChange={(event) => setQuery(event.target.value)}
+                                placeholder="캐릭터 이름을 검색하세요"
+                                autoComplete="off"
+                                autoFocus
+                                className="h-10 flex-1 border-0 bg-transparent p-0 text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                            />
+                        </div>
+                        <div className="flex flex-wrap justify-center gap-3">
+                            <Button
+                                type="submit"
+                                disabled={loading}
+                                className="h-12 rounded-full px-10 text-base font-semibold shadow-[0_18px_40px_-24px_rgba(79,70,229,0.75)]"
+                            >
+                                {loading ? (
+                                    <>
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                                        검색 중...
+                                    </>
+                                ) : (
+                                    'Search'
+                                )}
+                            </Button>
+                        </div>
+                    </form>
                 </div>
-                <form onSubmit={handleSearch} className="w-full space-y-6">
-                    <div className="flex items-center gap-3 rounded-full border border-input bg-background/80 px-6 py-4 shadow-sm transition focus-within:border-ring focus-within:ring-2 focus-within:ring-ring">
-                        <SearchIcon className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-                        <Input
-                            value={query}
-                            onChange={(event) => setQuery(event.target.value)}
-                            placeholder="캐릭터 이름을 검색하세요"
-                            autoComplete="off"
-                            autoFocus
-                            className="flex-1 border-0 bg-transparent p-0 text-lg shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                        />
-                    </div>
-                    <div className="flex flex-wrap justify-center gap-3">
-                        <Button
-                            type="submit"
-                            disabled={loading}
-                            className="rounded-full px-6 py-5 text-base font-medium"
-                        >
-                            {loading ? (
-                                <>
-                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-                                    검색 중...
-                                </>
-                            ) : (
-                                'Search'
-                            )}
-                        </Button>
-                    </div>
-                </form>
             </div>
         </div>
     );

--- a/src/app/layout/MainLayout.tsx
+++ b/src/app/layout/MainLayout.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import Header from "@/components/Header";
+import BackgroundPattern from "@/components/layouts/BackgroundPattern";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth, isGuestAccessiblePath, isUnauthenticatedAccessiblePath } from "@/providers/AuthProvider";
 
@@ -13,12 +14,20 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => {
     const unauthAccessible = pathname ? isUnauthenticatedAccessiblePath(pathname) : false;
 
     const renderSkeleton = () => (
-        <div className="flex h-screen flex-col">
-            <Skeleton className="h-[var(--header-height)] w-full" />
-            <div className="flex-1 w-full overflow-hidden p-4">
-                <Skeleton className="h-full w-full" />
+        <BackgroundPattern>
+            <header className="sticky top-0 z-50 border-b border-border/60 bg-card/80 backdrop-blur">
+                <div className="mx-auto flex h-[var(--header-height)] w-full max-w-6xl items-center px-4 sm:px-6 lg:px-8">
+                    <Skeleton className="h-10 w-full" />
+                </div>
+            </header>
+            <div className="flex flex-1">
+                <div className="mx-auto flex h-full min-h-[calc(100vh-var(--header-height))] w-full max-w-6xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+                    <div className="flex h-full w-full flex-1 flex-col overflow-hidden rounded-[32px] border border-border/60 bg-card/80 p-6 shadow-[0_40px_80px_-50px_rgba(15,23,42,0.45)] backdrop-blur-md">
+                        <Skeleton className="h-full w-full" />
+                    </div>
+                </div>
             </div>
-        </div>
+        </BackgroundPattern>
     );
 
     if (isLoading) {
@@ -34,12 +43,16 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => {
     }
 
     return (
-        <main className="flex h-screen flex-col">
+        <BackgroundPattern>
             <Header />
-            <main className="h-[calc(100vh-var(--header-height))] w-full flex-1 overflow-hidden p-4">
-                {children}
-            </main>
-        </main>
+            <div className="flex flex-1">
+                <div className="mx-auto flex h-full min-h-[calc(100vh-var(--header-height))] w-full max-w-6xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+                    <div className="flex h-full w-full flex-1 flex-col overflow-hidden rounded-[32px] border border-border/60 bg-card/80 p-6 shadow-[0_40px_80px_-50px_rgba(15,23,42,0.45)] backdrop-blur-md">
+                        {children}
+                    </div>
+                </div>
+            </div>
+        </BackgroundPattern>
     );
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,25 +8,32 @@ import SideMenu from '@/components/SideMenu';
 import { useAuth } from '@/providers/AuthProvider';
 
 const Header = () => {
-  const pathname = usePathname();
-  const { status, isGuest } = useAuth();
-  if (pathname === '/sign_in' || pathname === '/sign_up') return null;
+    const pathname = usePathname();
+    const { status, isGuest } = useAuth();
+    if (pathname === '/sign_in' || pathname === '/sign_up') return null;
 
-  const logoHref = isGuest || status === 'unauthenticated' ? '/search' : '/';
+    const logoHref = isGuest || status === 'unauthenticated' ? '/search' : '/';
 
-  return (
-    <header className="sticky top-0 z-50 flex h-[var(--header-height)] items-center justify-between border-b bg-background/90 px-4">
-      {/* 로고 */}
-      <Link href={logoHref} className="flex items-center">
-        <Image src="/Reheln.png" alt="Finder" width={40} height={40} priority />
-      </Link>
-      {/* 오른쪽 메뉴 */}
-      <div className="flex items-center space-x-2">
-        <DarkModeToggle />
-        <SideMenu />
-      </div>
-    </header>
-  );
+    return (
+        <header className="sticky top-0 z-50 border-b border-border/60 bg-card/80 backdrop-blur">
+            <div className="mx-auto flex h-[var(--header-height)] w-full max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
+                <Link
+                    href={logoHref}
+                    aria-label="Finder 홈으로 이동"
+                    className="group flex items-center gap-3 rounded-full border border-border/60 bg-background/80 px-3 py-1.5 text-sm font-semibold text-foreground/90 transition hover:border-primary/40 hover:text-primary"
+                >
+                    <span className="relative flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-primary/40 via-primary/30 to-primary/10 shadow-inner shadow-primary/20 transition group-hover:from-primary/60 group-hover:via-primary/40 group-hover:to-primary/20">
+                        <Image src="/Reheln.png" alt="Finder" width={24} height={24} priority className="drop-shadow-sm" />
+                    </span>
+                    <span className="hidden text-base font-semibold tracking-tight md:inline-block">Finder</span>
+                </Link>
+                <div className="flex items-center gap-1.5">
+                    <DarkModeToggle />
+                    <SideMenu />
+                </div>
+            </div>
+        </header>
+    );
 };
 
 export default Header;

--- a/src/components/layouts/BackgroundPattern.tsx
+++ b/src/components/layouts/BackgroundPattern.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/utils/utils';
+
+interface BackgroundPatternProps {
+    children: ReactNode;
+    className?: string;
+}
+
+const BackgroundPattern = ({ children, className }: BackgroundPatternProps) => {
+    return (
+        <div className={cn('relative flex min-h-screen w-full flex-col overflow-hidden bg-background', className)}>
+            <div className="pointer-events-none absolute inset-0">
+                <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-primary/5 opacity-70 dark:from-primary/5" />
+                <div className="absolute left-1/2 top-[-35%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-primary/20 opacity-40 blur-[160px]" />
+                <div className="absolute bottom-[-35%] left-[-10%] h-[480px] w-[480px] rounded-full bg-blue-500/15 opacity-30 blur-[160px] dark:bg-blue-400/10" />
+                <div className="absolute right-[-20%] top-1/3 h-[460px] w-[460px] rounded-full bg-amber-400/20 opacity-35 blur-[160px] dark:bg-amber-300/10" />
+                <div className="absolute inset-0 bg-[linear-gradient(90deg,rgba(148,163,184,0.18)_1px,transparent_1px),linear-gradient(0deg,rgba(148,163,184,0.18)_1px,transparent_1px)] bg-[length:60px_60px] opacity-[0.18] dark:opacity-10" />
+            </div>
+            <div className="relative flex min-h-screen flex-1 flex-col">{children}</div>
+        </div>
+    );
+};
+
+export default BackgroundPattern;


### PR DESCRIPTION
## Summary
- add a reusable BackgroundPattern wrapper that provides the new gradient backdrop
- update MainLayout and Header to use the centered glassmorphism shell
- restyle the sign-in, sign-up, and search screens to match the refreshed UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca3a9e21108324996182c705452fd0