### PR TITLE
Handle invalid view transition errors when toggling theme

### DIFF
--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -29,9 +29,20 @@ const DarkModeToggle = () => {
     const doc = document as DocumentWithViewTransition;
 
     if (typeof doc.startViewTransition === 'function') {
-      doc.startViewTransition(() => {
+      try {
+        doc.startViewTransition(() => {
+          applyTheme();
+        });
+      } catch (error) {
+        const isInvalidStateError =
+          error instanceof DOMException && error.name === 'InvalidStateError';
+
+        if (!isInvalidStateError) {
+          console.warn('Failed to start view transition', error);
+        }
+
         applyTheme();
-      });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- wrap the dark mode toggle's view transition usage in a try/catch so InvalidStateError falls back to applying the theme
- log unexpected failures and ensure the theme still toggles when a transition cannot start

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca43e98f1c83248ceca3d828e3f5c2