### PR TITLE
Fix get started routing for authenticated users

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -15,24 +15,18 @@ import { useAuth } from '@/providers/AuthProvider';
 const SignInPage = () => {
     const router = useRouter();
     const setApiKey = userStore((s) => s.setApiKey);
-    const { loginAsGuest } = useAuth();
+    const { loginAsGuest, status, isLoading } = useAuth();
     const [form, setForm] = useState({ email: '', password: '' });
     const [loading, setLoading] = useState(false);
     const [googleLoading, setGoogleLoading] = useState(false);
     const [guestLoading, setGuestLoading] = useState(false);
 
     useEffect(() => {
-        const loadSession = async () => {
-            const { data } = await supabase.auth.getSession();
-            const session = data.session;
-            if (session) {
-                const key = session.user.user_metadata?.nexon_api_key;
-                if (key) setApiKey(key);
-                router.replace('/');
-            }
-        };
-        loadSession();
-    }, [router, setApiKey]);
+        if (isLoading) return;
+        if (status === 'authenticated') {
+            router.replace('/search');
+        }
+    }, [isLoading, router, status]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight, BarChart3, Search, ShieldCheck, Sparkles, } from "lucide-react";
+import GetStartedButton from "@/components/home/GetStartedButton";
 
 const HIGHLIGHTS = [
     {
@@ -21,12 +22,6 @@ const HIGHLIGHTS = [
             "공식 API와 인증을 통해 수집된 데이터를 암호화하여 저장하고, 개인 정보 보호를 보장합니다.",
         Icon: ShieldCheck,
     },
-];
-
-const STATS = [
-    { label: "분석된 캐릭터", value: "128K+" },
-    { label: "보스 전투 로그", value: "2.4M+" },
-    { label: "추천된 사냥 루트", value: "86K+" },
 ];
 
 const Page = () => {
@@ -71,13 +66,7 @@ const Page = () => {
                             AI가 추천하는 다음 플레이를 만나보세요.
                         </p>
                         <div className="mt-10 flex w-full flex-col gap-4 sm:w-auto sm:flex-row">
-                            <Link
-                                href="/sign_in"
-                                className="group inline-flex items-center justify-center rounded-full bg-white px-8 py-3 text-base font-semibold text-slate-950 shadow-[0_18px_45px_-20px_rgba(56,189,248,0.8)] transition hover:-translate-y-0.5 hover:shadow-[0_24px_65px_-25px_rgba(14,165,233,0.9)]"
-                            >
-                                지금 시작하기
-                                <ArrowRight className="ml-2 h-5 w-5 transition group-hover:translate-x-1" />
-                            </Link>
+                            <GetStartedButton />
                             <Link
                                 href="/search"
                                 className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white/[0.08] px-8 py-3 text-base font-semibold text-slate-100 backdrop-blur transition hover:-translate-y-0.5 hover:border-sky-300/60 hover:bg-slate-900/60"

--- a/src/components/home/GetStartedButton.tsx
+++ b/src/components/home/GetStartedButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { useAuth } from '@/providers/AuthProvider';
+
+const GetStartedButton = () => {
+    const router = useRouter();
+    const { status, isLoading } = useAuth();
+
+    const handleClick = useCallback(() => {
+        if (isLoading) return;
+
+        if (status === 'authenticated') {
+            router.push('/search');
+            return;
+        }
+
+        router.push('/sign_in');
+    }, [isLoading, router, status]);
+
+    return (
+        <button
+            type="button"
+            onClick={handleClick}
+            disabled={isLoading}
+            className="group inline-flex items-center justify-center rounded-full bg-white px-8 py-3 text-base font-semibold text-slate-950 shadow-[0_18px_45px_-20px_rgba(56,189,248,0.8)] transition hover:-translate-y-0.5 hover:shadow-[0_24px_65px_-25px_rgba(14,165,233,0.9)] disabled:cursor-not-allowed disabled:opacity-70"
+        >
+            지금 시작하기
+            <ArrowRight className="ml-2 h-5 w-5 transition group-hover:translate-x-1" />
+        </button>
+    );
+};
+
+export default GetStartedButton;


### PR DESCRIPTION
## Summary
- add a client get started button that routes authenticated users directly to Search and sends others to the sign-in flow
- update the sign-in page to rely on the shared auth status before redirecting and clean up the unused stats constant on the landing page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ca49647b9083248d56cadf2ad15b9a