### PR TITLE
Update post-auth redirects to home

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -57,14 +57,11 @@ const SignInPage = () => {
 
     const handleGoogle = async () => {
         setGoogleLoading(true);
-        const options =
-            window.location.hostname === 'localhost'
-                ? undefined
-                : { redirectTo: window.location.origin };
+        const redirectTo = `${window.location.origin}/home`;
 
         const { error } = await supabase.auth.signInWithOAuth({
             provider: 'google',
-            options,
+            options: { redirectTo },
         });
         if (error) {
             toast.error(error.message);

--- a/src/app/(auth)/sign_up/page.tsx
+++ b/src/app/(auth)/sign_up/page.tsx
@@ -35,7 +35,7 @@ const SignUpPage = () => {
             setApiKey(apiKey);
         }
         toast.success(`${form.email}로 인증 메일이 발송되었습니다. 확인해 주세요.`);
-        router.push('/');
+        router.push('/home');
         setLoading(false);
     };
 

--- a/src/app/(main)/character_list/page.tsx
+++ b/src/app/(main)/character_list/page.tsx
@@ -2,6 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { characterListStore } from "@/stores/characterListStore";
+import { favoriteStore } from "@/stores/favoriteStore";
+import { userStore } from "@/stores/userStore";
 import { supabase } from "@/libs/supabaseClient";
 import CharacterCardSkeleton from "@/components/character/CharacterCardSkeleton";
 import CharacterCell from "@/components/character/CharacterCell";
@@ -10,9 +13,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Skeleton } from "@/components/ui/skeleton";
 import { addFavorite, getFavorites, removeFavorite } from "@/fetchs/favorite.fetch";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
-import { characterListStore } from "@/stores/characterListStore";
-import { favoriteStore } from "@/stores/favoriteStore";
-import { userStore } from "@/stores/userStore";
 
 const CharacterList = () => {
     const setApiKey = userStore((s) => s.setApiKey);

--- a/src/app/(main)/chat/page.tsx
+++ b/src/app/(main)/chat/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, unstable_ViewTransition as ViewTransition, useEffect, useRef, useState, } from "react";
 import { Bot, Loader2, Send, Trash2, User } from "lucide-react";
+import { chatStore } from "@/stores/chatStore";
 import { buildPromptContext } from "@/libs/promptContext";
 import type { ChatHistoryMessage } from "@/types/ai/chat";
 import { Button } from "@/components/ui/button";
@@ -9,7 +10,6 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { requestAiChat } from "@/fetchs/ai/chat.fetch";
-import { chatStore } from "@/stores/chatStore";
 import { cn } from "@/utils/utils";
 
 const ChatPage = () => {

--- a/src/app/(main)/figure/page.tsx
+++ b/src/app/(main)/figure/page.tsx
@@ -4,12 +4,12 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { unstable_ViewTransition as ViewTransition, useCallback, useEffect, useMemo, useRef, useState, } from "react";
 import { ArrowLeft, Loader2, RefreshCcw } from "lucide-react";
+import { characterDetailStore } from "@/stores/characterDetailStore";
 import type { FigureGenerationMetadata, FigureResult } from "@/types/figure";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { requestCharacterFigure } from "@/fetchs/figure.fetch";
-import { characterDetailStore } from "@/stores/characterDetailStore";
 
 const FigurePage = () => {
     const router = useRouter();

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { unstable_ViewTransition as ViewTransition, useEffect, useState } from "react";
+import { favoriteStore } from "@/stores/favoriteStore";
 import { supabase } from "@/libs/supabaseClient";
 import CharacterInfo from "@/components/home/CharacterInfo";
 import FavoriteList from "@/components/home/FavoriteList";
@@ -9,7 +10,6 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { findCharacterBasic } from "@/fetchs/character.fetch";
 import { addFavorite, getFavorites, removeFavorite } from "@/fetchs/favorite.fetch";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
-import { favoriteStore } from "@/stores/favoriteStore";
 
 const Home = () => {
     const router = useRouter();

--- a/src/app/(main)/my_page/page.tsx
+++ b/src/app/(main)/my_page/page.tsx
@@ -3,12 +3,12 @@
 import { useSearchParams } from 'next/navigation';
 import { FormEvent, Suspense, useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { userStore } from '@/stores/userStore';
 import { supabase } from '@/libs/supabaseClient';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
-import { userStore } from '@/stores/userStore';
 
 const FormSkeleton = () => (
   <div className="flex justify-center p-4">

--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { unstable_ViewTransition as ViewTransition, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { characterDetailStore } from "@/stores/characterDetailStore";
 import CharacterBanner from "@/components/character/CharacterBanner";
 import { Ability } from "@/components/character/detail/Ability";
 import { Android } from "@/components/character/detail/Android";
@@ -31,7 +32,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { findCharacterAbility, findCharacterAndroidEquipment, findCharacterBasic, findCharacterBeautyEquipment, findCharacterCashItemEquipment, findCharacterDojang, findCharacterHexaMatrix, findCharacterHexaMatrixStat, findCharacterHyperStat, findCharacterItemEquipment, findCharacterLinkSkill, findCharacterOtherStat, findCharacterPetEquipment, findCharacterPopularity, findCharacterPropensity, findCharacterRingExchange, findCharacterSetEffect, findCharacterSkill, findCharacterStat, findCharacterSymbolEquipment, findCharacterVMatrix, } from "@/fetchs/character.fetch";
 import { findGuildBasic, findGuildId } from "@/fetchs/guild.fetch";
 import { findUnion, findUnionArtifact, findUnionRaider } from "@/fetchs/union.fetch";
-import { characterDetailStore } from "@/stores/characterDetailStore";
 
 const CharacterDetail = ({ ocid }: { ocid: string }) => {
     const {

--- a/src/fetchs/character.fetch.ts
+++ b/src/fetchs/character.fetch.ts
@@ -1,9 +1,9 @@
 import axios, { AxiosError } from "axios";
 import pLimit from "p-limit";
+import { userStore } from "@/stores/userStore";
 import { ICharacterAbility, ICharacterAndroidEquipment, ICharacterBasic, ICharacterBeautyEquipment, ICharacterCashItemEquipment, ICharacterDojang, ICharacterHexaMatrix, ICharacterHexaMatrixStat, ICharacterHyperStat, ICharacterItemEquipment, ICharacterLinkSkill, ICharacterOtherStat, ICharacterPetEquipment, ICharacterPopularity, ICharacterPropensity, ICharacterSetEffect, ICharacterSkill, ICharacterStat, ICharacterSymbolEquipment, ICharacterVMatrix, IRingExchangeSkillEquipment, } from "@/interface/character/ICharacter";
 import { ICharacterResponse } from "@/interface/character/ICharacterResponse";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
-import { userStore } from "@/stores/userStore";
 
 const getApiKeyInfo = () => {
     const { apiKey, isGuest } = userStore.getState().user;

--- a/src/fetchs/guild.fetch.ts
+++ b/src/fetchs/guild.fetch.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios";
+import { userStore } from "@/stores/userStore";
 import { IGuildBasic, IGuildId } from "@/interface/guild/IGuild";
 import { IGuildResponse } from "@/interface/guild/IGuildResponse";
-import { userStore } from "@/stores/userStore";
 
 const getApiKeyInfo = () => {
     const { apiKey, isGuest } = userStore.getState().user;

--- a/src/fetchs/union.fetch.ts
+++ b/src/fetchs/union.fetch.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios";
+import { userStore } from "@/stores/userStore";
 import { IUnion, IUnionRaider, IUnionArtifact, IUnionChampion } from "@/interface/union/IUnion";
 import { IUnionResponse } from "@/interface/union/IUnionResponse";
-import { userStore } from "@/stores/userStore";
 
 const getApiKeyInfo = () => {
     const { apiKey, isGuest } = userStore.getState().user;


### PR DESCRIPTION
## Summary
- update the Google OAuth sign-in flow to request a `/home` redirect so users land on the home dashboard after authenticating
- send users to `/home` after completing the email/password sign-up flow instead of the landing page
- run the lint autofix to satisfy the import ordering rules that place store imports before other local modules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca4d524668832493eee99046b1223e