### PR TITLE
Fix logout toast and OAuth redirect handling

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -13,6 +13,24 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/providers/AuthProvider';
 
+const getSiteUrl = () => {
+    const envUrl =
+        process.env.NEXT_PUBLIC_SITE_URL ??
+        (process.env.NEXT_PUBLIC_VERCEL_URL
+            ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+            : undefined);
+
+    if (envUrl) {
+        return envUrl.replace(/\/+$/, "");
+    }
+
+    if (typeof window !== 'undefined') {
+        return window.location.origin;
+    }
+
+    return 'http://localhost:3000';
+};
+
 const SignInPage = () => {
     const router = useRouter();
     const setApiKey = userStore((s) => s.setApiKey);
@@ -58,7 +76,7 @@ const SignInPage = () => {
 
     const handleGoogle = async () => {
         setGoogleLoading(true);
-        const redirectTo = `${window.location.origin}/home`;
+        const redirectTo = `${getSiteUrl()}/sign_in`;
 
         const { error } = await supabase.auth.signInWithOAuth({
             provider: 'google',

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -66,6 +66,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const applyAuthState = useApplyAuthState();
     const redirectToastPathRef = useRef<string | null>(null);
     const skipGuestGuardToastRef = useRef(false);
+    const skipUnauthenticatedToastRef = useRef(false);
 
     const syncSession = useCallback(async () => {
         setIsLoading(true);
@@ -100,6 +101,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         if (typeof window !== "undefined") {
             localStorage.removeItem(GUEST_STORAGE_KEY);
         }
+        skipUnauthenticatedToastRef.current = true;
         applyAuthState(null, false, setStatus, setIsLoading);
     }, [applyAuthState, status]);
 
@@ -121,9 +123,13 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         if (status === "unauthenticated" && pathname) {
             if (isPublicPath(pathname) || isUnauthenticatedAccessiblePath(pathname)) {
                 redirectToastPathRef.current = null;
+                skipUnauthenticatedToastRef.current = false;
                 return;
             }
-            toast.info("로그인이 필요한 서비스입니다");
+            if (!skipUnauthenticatedToastRef.current) {
+                toast.info("로그인이 필요한 서비스입니다");
+            }
+            skipUnauthenticatedToastRef.current = false;
             router.replace("/sign_in");
             return;
         }


### PR DESCRIPTION
## Summary
- skip the login required toast after an intentional logout while keeping guard redirects
- add environment-aware site url helper so Google OAuth redirects back to the sign-in page on the correct domain

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca5c6106b48324b1c2a2adede185f3