### PR TITLE
Add shared element transition for character detail images

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -96,7 +96,15 @@ const Home = () => {
     };
 
     const goToDetailPage = () => {
-        router.push(`/character/${selected}`);
+        if (!selected) return;
+        const target = selected;
+        const navigate = () => router.push(`/character/${target}`);
+        if (typeof document !== "undefined" && "startViewTransition" in document) {
+            // @ts-expect-error: startViewTransition is not yet in the DOM typings
+            document.startViewTransition(navigate);
+        } else {
+            navigate();
+        }
     };
 
     return (

--- a/src/components/character/CharacterBanner.tsx
+++ b/src/components/character/CharacterBanner.tsx
@@ -25,6 +25,10 @@ type CharacterBannerProps = {
     backgroundColor?: string
     /** Optional background image shown behind the character */
     backgroundImage?: string
+    /** Preloaded image url shared from the summary panel */
+    imageSrc?: string
+    /** Shared element transition name */
+    imageTransitionName?: string
 }
 
 const CharacterBanner = ({
@@ -37,9 +41,15 @@ const CharacterBanner = ({
     imageScale,
     backgroundColor = "bg-card",
     backgroundImage,
+    imageSrc,
+    imageTransitionName,
 }: CharacterBannerProps) => {
     const router = useRouter();
     const { status } = useAuth();
+    const bannerImageSrc = imageSrc ?? (basic?.character_image
+        ? `/api/crop?url=${encodeURIComponent(basic.character_image)}`
+        : null
+    );
 
     const getFigure = () => {
         if (!basic?.character_image) return;
@@ -141,14 +151,20 @@ const CharacterBanner = ({
                                 {basic.character_name}
                             </div>
                         </div>
-                        {basic.character_image && (
+                        {bannerImageSrc && (
                             <div
                                 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
-                                style={{ transform: `scale(${imageScale})`, opacity: imageScale }}
+                                style={{
+                                    transform: `scale(${imageScale})`,
+                                    opacity: imageScale,
+                                    ...(imageTransitionName
+                                        ? { viewTransitionName: imageTransitionName }
+                                        : {}),
+                                }}
                             >
                                 <Image
-                                    src={`/api/crop?url=${encodeURIComponent(basic.character_image)}`}
-                                    alt={basic.character_name}
+                                    src={bannerImageSrc}
+                                    alt={basic?.character_name ?? "character"}
                                     width={120}
                                     height={120}
                                     className="object-contain h-auto"

--- a/src/stores/characterDetailStore.ts
+++ b/src/stores/characterDetailStore.ts
@@ -70,7 +70,7 @@ type CharacterDetailSlice = {
     setAbility: (ability: CharacterDetailSlice['ability']) => void
 
     // util
-    reset: () => void
+    reset: (state?: Partial<CharacterDetailState>) => void
 }
 
 const initialState: Omit<
@@ -135,6 +135,8 @@ const initialState: Omit<
     ability: null,
 };
 
+type CharacterDetailState = typeof initialState;
+
 export const characterDetailStore = create<CharacterDetailSlice>()(
     persist(
         (set) => ({
@@ -166,7 +168,7 @@ export const characterDetailStore = create<CharacterDetailSlice>()(
             setPet: (pet) => set({ pet }),
             setPropensity: (propensity) => set({ propensity }),
             setAbility: (ability) => set({ ability }),
-            reset: () => set(initialState),
+            reset: (state) => set({ ...initialState, ...state }),
         }),
         {
             name: "characterDetailStore",

--- a/src/stores/characterPreviewStore.ts
+++ b/src/stores/characterPreviewStore.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+import { ICharacterBasic } from "@/interface/character/ICharacter";
+
+type CharacterPreviewState = {
+    ocid: string | null;
+    basic: ICharacterBasic | null;
+    setPreview: (ocid: string, basic: ICharacterBasic) => void;
+    clear: () => void;
+};
+
+export const useCharacterPreviewStore = create<CharacterPreviewState>()((set) => ({
+    ocid: null,
+    basic: null,
+    setPreview: (ocid, basic) => set({ ocid, basic }),
+    clear: () => set({ ocid: null, basic: null }),
+}));


### PR DESCRIPTION
## Summary
- cache the selected character's basic data in a preview store so the detail page can reuse the already loaded image
- update CharacterInfo, CharacterDetail, and CharacterBanner to apply shared element view transitions when navigating
- adjust the detail store reset helper and navigation handler to work with the preview image during transitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca6cda555083249187ad977d78c9c0