### PR TITLE
Add Kakao SSO login and update social sign-in buttons

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { type SVGProps, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { userStore } from '@/stores/userStore';
 import { supabase } from '@/libs/supabaseClient';
@@ -13,6 +13,48 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/providers/AuthProvider';
 
+type IconProps = SVGProps<SVGSVGElement>;
+
+const GoogleIcon = (props: IconProps) => (
+    <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        {...props}
+    >
+        <path
+            fill="#EA4335"
+            d="M12.24 10.26v3.54h5.05c-.21 1.18-.83 2.18-1.78 2.85l2.86 2.22c1.67-1.54 2.66-3.82 2.66-6.61 0-.63-.06-1.23-.17-1.8z"
+        />
+        <path
+            fill="#4285F4"
+            d="M12 5.5c1.63 0 3.1.56 4.26 1.65l2.62-2.62C16.83 2.6 14.63 1.75 12 1.75 7.79 1.75 4.13 4.2 2.56 7.87l3.1 2.38C6.53 7.47 8.98 5.5 12 5.5z"
+        />
+        <path
+            fill="#FBBC05"
+            d="M12 22.25c2.58 0 4.93-.85 6.57-2.31l-2.86-2.22c-.8.55-1.85.93-3.71.93-2.99 0-5.51-1.99-6.42-4.68l-3.1 2.39C4.05 19.92 7.64 22.25 12 22.25z"
+        />
+        <path
+            fill="#34A853"
+            d="M5.58 13.97a6.72 6.72 0 0 1-.33-2.22c0-.77.12-1.51.33-2.22l-3.1-2.38A10.17 10.17 0 0 0 1.75 11.75c0 1.61.37 3.14 1.1 4.6z"
+        />
+        <path fill="none" d="M1.75 1.75h20.5v20.5H1.75z" />
+    </svg>
+);
+
+const KakaoIcon = (props: IconProps) => (
+    <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        {...props}
+    >
+        <rect width="24" height="24" rx="6" fill="#FEE500" />
+        <path
+            fill="#381E1F"
+            d="M12 6.25c-3.44 0-6.25 2.04-6.25 4.57 0 1.69 1.12 3.16 2.83 3.99l-.87 2.63 2.64-1.62c.51.09 1.04.13 1.65.13 3.44 0 6.25-2.04 6.25-4.57S15.44 6.25 12 6.25z"
+        />
+    </svg>
+);
+
 const SignInPage = () => {
     const router = useRouter();
     const setApiKey = userStore((s) => s.setApiKey);
@@ -21,6 +63,12 @@ const SignInPage = () => {
     const [loading, setLoading] = useState(false);
     const [googleLoading, setGoogleLoading] = useState(false);
     const [guestLoading, setGuestLoading] = useState(false);
+    const [kakaoLoading, setKakaoLoading] = useState(false);
+
+    const createRedirectTo = () => {
+        const siteUrl = process.env.NEXT_PUBLIC_VERCEL_URL ?? window.location.origin;
+        return `${siteUrl}/home`;
+    };
 
     useEffect(() => {
         const loadSession = async () => {
@@ -58,17 +106,37 @@ const SignInPage = () => {
 
     const handleGoogle = async () => {
         setGoogleLoading(true);
+        try {
+            const { error } = await supabase.auth.signInWithOAuth({
+                provider: 'google',
+                options: { redirectTo: createRedirectTo() },
+            });
 
-        const siteUrl = process.env.NEXT_PUBLIC_VERCEL_URL ?? window.location.origin;
-        const redirectTo = `${siteUrl}/home`;
-        const { error } = await supabase.auth.signInWithOAuth({
-            provider: 'google',
-            options: { redirectTo },
-        });
-
-        if (error) {
-            toast.error(error.message);
+            if (error) {
+                toast.error(error.message);
+                setGoogleLoading(false);
+            }
+        } catch {
+            toast.error('구글 로그인 중 문제가 발생했습니다.');
             setGoogleLoading(false);
+        }
+    };
+
+    const handleKakao = async () => {
+        setKakaoLoading(true);
+        try {
+            const { error } = await supabase.auth.signInWithOAuth({
+                provider: 'kakao',
+                options: { redirectTo: createRedirectTo() },
+            });
+
+            if (error) {
+                toast.error(error.message);
+                setKakaoLoading(false);
+            }
+        } catch {
+            toast.error('카카오 로그인 중 문제가 발생했습니다.');
+            setKakaoLoading(false);
         }
     };
 
@@ -126,11 +194,22 @@ const SignInPage = () => {
                     <Button
                         type="button"
                         variant="outline"
-                        className="w-full"
+                        className="w-full gap-2"
                         onClick={handleGoogle}
-                        disabled={googleLoading}
+                        disabled={googleLoading || kakaoLoading}
                     >
-                        {googleLoading ? 'Sign in with Google...' : 'Sign in with Google'}
+                        <GoogleIcon className="h-5 w-5" />
+                        {googleLoading ? '구글로 로그인 중...' : '구글로 로그인'}
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full gap-2"
+                        onClick={handleKakao}
+                        disabled={kakaoLoading || googleLoading}
+                    >
+                        <KakaoIcon className="h-5 w-5" />
+                        {kakaoLoading ? '카카오로 로그인 중...' : '카카오로 로그인'}
                     </Button>
                     <div className="relative flex items-center">
                         <div className="flex-grow border-t border-gray-300" />


### PR DESCRIPTION
## Summary
- add inline Google and Kakao SVG icons for the social login buttons on the sign-in page
- add Kakao OAuth login handling via Supabase with shared redirect helper and localized loading text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca76422ffc832490490ca28f8bc9a9