### PR TITLE
Refactor API fetch helpers to use shared client

### DIFF
--- a/src/fetchs/apiClient.ts
+++ b/src/fetchs/apiClient.ts
@@ -1,0 +1,101 @@
+import axios, { AxiosError } from "axios";
+import pLimit from "p-limit";
+import { userStore } from "@/stores/userStore";
+
+export type ApiParams = Record<string, string | number | undefined>;
+
+type RequestTask<T> = () => Promise<T>;
+
+const filterUndefinedParams = (params: ApiParams) =>
+    Object.fromEntries(
+        Object.entries(params).filter(([, value]) => value !== undefined),
+    );
+
+const redirectToMissingApiKey = (isGuest: boolean) => {
+    if (!isGuest && typeof window !== "undefined") {
+        window.location.href = "/my_page?missingApiKey=1";
+    }
+};
+
+export const getApiKeyInfo = () => {
+    const { apiKey, isGuest } = userStore.getState().user;
+    const fallback = process.env.NEXT_PUBLIC_NEXON_API_KEY ?? "";
+    return {
+        key: apiKey ?? fallback,
+        isGuest: Boolean(isGuest),
+    };
+};
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export type RequestRunner = <T>(task: RequestTask<T>) => Promise<T>;
+
+type RequestRunnerOptions = {
+    concurrency?: number;
+    delayMs?: number;
+};
+
+export const createRequestRunner = ({
+    concurrency,
+    delayMs,
+}: RequestRunnerOptions = {}): RequestRunner => {
+    const limiter = typeof concurrency === "number" ? pLimit(concurrency) : null;
+    let queue: Promise<unknown> = Promise.resolve();
+
+    return <T>(task: RequestTask<T>) => {
+        const execute = async () => {
+            if (delayMs) {
+                await delay(delayMs);
+            }
+            return task();
+        };
+
+        if (limiter) {
+            return limiter(execute);
+        }
+
+        if (delayMs) {
+            const result = queue.then(execute);
+            queue = result.catch(() => undefined);
+            return result;
+        }
+
+        return execute();
+    };
+};
+
+const defaultRunner: RequestRunner = (task) => task();
+
+type ApiCallerOptions = {
+    basePath?: string;
+    runner?: RequestRunner;
+};
+
+export const createApiCaller = ({
+    basePath = "",
+    runner = defaultRunner,
+}: ApiCallerOptions = {}) =>
+    async <TResponse>(endpoint: string, params: ApiParams = {}): Promise<TResponse> => {
+        const { key, isGuest } = getApiKeyInfo();
+        const url = basePath ? `/api/${basePath}/${endpoint}` : `/api/${endpoint}`;
+
+        const runRequest = async () => {
+            try {
+                const response = await axios.get<TResponse>(url, {
+                    headers: { "x-nxopen-api-key": key },
+                    params: filterUndefinedParams(params),
+                });
+                return response.data;
+            } catch (error) {
+                if (
+                    error instanceof AxiosError &&
+                    error.response?.data?.error?.message === "Missing API Key"
+                ) {
+                    redirectToMissingApiKey(isGuest);
+                }
+                throw error;
+            }
+        };
+
+        return runner(runRequest);
+    };

--- a/src/fetchs/guild.fetch.ts
+++ b/src/fetchs/guild.fetch.ts
@@ -1,57 +1,15 @@
-import axios, { AxiosError } from "axios";
-import { userStore } from "@/stores/userStore";
+import { createApiCaller, createRequestRunner, type ApiParams } from "@/fetchs/apiClient";
 import { IGuildBasic, IGuildId } from "@/interface/guild/IGuild";
 import { IGuildResponse } from "@/interface/guild/IGuildResponse";
 
-const getApiKeyInfo = () => {
-    const { apiKey, isGuest } = userStore.getState().user;
-    const fallback = process.env.NEXT_PUBLIC_NEXON_API_KEY ?? "";
-    return {
-        key: apiKey ?? fallback,
-        isGuest: Boolean(isGuest),
-    };
-};
+const queueRunner = createRequestRunner({ delayMs: 200 });
+const callGuildApiBase = createApiCaller({ basePath: "guild", runner: queueRunner });
 
-const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-let requestQueue: Promise<unknown> = Promise.resolve();
-
-const callGuildApi = async <T>(
+const callGuildApi = <T>(
     endpoint: string,
-    params: Record<string, string | number | undefined> = {}
-): Promise<IGuildResponse<T>> => {
-    const { key, isGuest } = getApiKeyInfo();
-
-    const task = async () => {
-        await delay(200);
-        try {
-            const response = await axios.get<IGuildResponse<T>>(
-                `/api/guild/${endpoint}`,
-                {
-                    headers: { "x-nxopen-api-key": key },
-                    params: Object.fromEntries(
-                        Object.entries(params).filter(([, v]) => v !== undefined)
-                    ),
-                }
-            );
-            return response.data;
-        } catch (err) {
-            if (
-                err instanceof AxiosError &&
-                err.response?.data?.error?.message === "Missing API Key"
-            ) {
-                if (!isGuest && typeof window !== "undefined") {
-                    window.location.href = "/my_page?missingApiKey=1";
-                }
-            }
-            throw err;
-        }
-    };
-
-    const result = requestQueue.then(task);
-    requestQueue = result.catch(() => undefined);
-    return result;
-};
+    params: ApiParams = {},
+): Promise<IGuildResponse<T>> =>
+    callGuildApiBase<IGuildResponse<T>>(endpoint, params);
 
 export const findGuildId = (guild_name: string, world_name: string) =>
     callGuildApi<IGuildId>("id", { guild_name, world_name });

--- a/src/fetchs/union.fetch.ts
+++ b/src/fetchs/union.fetch.ts
@@ -1,54 +1,15 @@
-import axios, { AxiosError } from "axios";
-import { userStore } from "@/stores/userStore";
+import { createApiCaller, createRequestRunner, type ApiParams } from "@/fetchs/apiClient";
 import { IUnion, IUnionRaider, IUnionArtifact, IUnionChampion } from "@/interface/union/IUnion";
 import { IUnionResponse } from "@/interface/union/IUnionResponse";
 
-const getApiKeyInfo = () => {
-    const { apiKey, isGuest } = userStore.getState().user;
-    const fallback = process.env.NEXT_PUBLIC_NEXON_API_KEY ?? "";
-    return {
-        key: apiKey ?? fallback,
-        isGuest: Boolean(isGuest),
-    };
-};
+const queueRunner = createRequestRunner({ delayMs: 200 });
+const callUnionApiBase = createApiCaller({ basePath: "union", runner: queueRunner });
 
-const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-let requestQueue: Promise<unknown> = Promise.resolve();
-
-const callUnionApi = async <T>(
+const callUnionApi = <T>(
     endpoint: string,
-    params: Record<string, string | number | undefined> = {}
-): Promise<IUnionResponse<T>> => {
-    const { key, isGuest } = getApiKeyInfo();
-
-    const task = async () => {
-        await delay(200);
-        try {
-            const response = await axios.get<IUnionResponse<T>>(`/api/union/${endpoint}`, {
-                headers: { "x-nxopen-api-key": key },
-                params: Object.fromEntries(
-                    Object.entries(params).filter(([, v]) => v !== undefined)
-                ),
-            });
-            return response.data;
-        } catch (err) {
-            if (
-                err instanceof AxiosError &&
-                err.response?.data?.error?.message === "Missing API Key"
-            ) {
-                if (!isGuest && typeof window !== "undefined") {
-                    window.location.href = "/my_page?missingApiKey=1";
-                }
-            }
-            throw err;
-        }
-    };
-
-    const result = requestQueue.then(task);
-    requestQueue = result.catch(() => undefined);
-    return result;
-};
+    params: ApiParams = {},
+): Promise<IUnionResponse<T>> =>
+    callUnionApiBase<IUnionResponse<T>>(endpoint, params);
 
 export const findUnion = (ocid: string, date?: string) =>
     callUnionApi<IUnion>("union", { ocid, date });


### PR DESCRIPTION
## Summary
- centralize axios GET calls, API key lookup, and throttling in a shared client helper
- update character fetch utilities to use the shared helper while preserving concurrency limit
- update union and guild fetch modules to reuse the shared queue runner instead of duplicating logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca936ba1ac83249f05340a15d83a6f