### PR TITLE
Fix Google OAuth redirect handling

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -66,8 +66,12 @@ const SignInPage = () => {
     const [kakaoLoading, setKakaoLoading] = useState(false);
 
     const createRedirectTo = () => {
-        const siteUrl = process.env.NEXT_PUBLIC_VERCEL_URL ?? window.location.origin;
-        return `${siteUrl}/home`;
+        const envUrl = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_VERCEL_URL;
+        const envUrlValue = envUrl && envUrl !== 'undefined' ? envUrl : undefined;
+        const fallbackUrl = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000';
+        const baseUrl = envUrlValue ?? fallbackUrl;
+        const normalizedUrl = baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`;
+        return `${normalizedUrl.replace(/\/$/, '')}/home`;
     };
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- normalize the Supabase OAuth redirect URL so it always includes a protocol
- fall back to the current origin to keep local logins redirecting to /home

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca950808a88324b6dabcfee83e32c2