### PR TITLE
Add bilingual support with language toggle

### DIFF
--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -8,10 +8,12 @@ import { toast } from 'sonner';
 import { userStore } from '@/stores/userStore';
 import { supabase } from '@/libs/supabaseClient';
 import DarkModeToggle from "@/components/DarkModeToggle";
+import LanguageToggle from "@/components/LanguageToggle";
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/providers/AuthProvider';
+import { useTranslations } from '@/providers/LanguageProvider';
 
 type IconProps = SVGProps<SVGSVGElement>;
 
@@ -64,6 +66,7 @@ const SignInPage = () => {
     const [googleLoading, setGoogleLoading] = useState(false);
     const [guestLoading, setGuestLoading] = useState(false);
     const [kakaoLoading, setKakaoLoading] = useState(false);
+    const t = useTranslations();
 
     const createRedirectTo = () => {
         const envUrl = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_VERCEL_URL;
@@ -103,7 +106,7 @@ const SignInPage = () => {
         if (apiKey) {
             setApiKey(apiKey);
         }
-        toast.success('로그인 성공');
+        toast.success(t('auth.signIn.toast.success'));
         router.push('/home');
         setLoading(false);
     };
@@ -121,7 +124,7 @@ const SignInPage = () => {
                 setGoogleLoading(false);
             }
         } catch {
-            toast.error('구글 로그인 중 문제가 발생했습니다.');
+            toast.error(t('auth.signIn.toast.googleError'));
             setGoogleLoading(false);
         }
     };
@@ -139,7 +142,7 @@ const SignInPage = () => {
                 setKakaoLoading(false);
             }
         } catch {
-            toast.error('카카오 로그인 중 문제가 발생했습니다.');
+            toast.error(t('auth.signIn.toast.kakaoError'));
             setKakaoLoading(false);
         }
     };
@@ -148,7 +151,7 @@ const SignInPage = () => {
         setGuestLoading(true);
         try {
             loginAsGuest();
-            toast.success('게스트로 입장했습니다.');
+            toast.success(t('auth.signIn.toast.guestSuccess'));
             router.push('/search');
         } finally {
             setGuestLoading(false);
@@ -157,7 +160,10 @@ const SignInPage = () => {
 
     return (
         <div className="flex min-h-screen">
-            <DarkModeToggle className='absolute top-1 left-full'/>
+            <div className='absolute top-1 left-full flex translate-x-2 flex-col gap-1.5 sm:flex-row sm:translate-x-0'>
+                <LanguageToggle />
+                <DarkModeToggle />
+            </div>
             <div className="relative hidden w-1/2 md:block">
                 <Image
                     src="/images/artwork_117.jpg"
@@ -170,10 +176,10 @@ const SignInPage = () => {
             <div className="flex flex-1 items-center justify-center p-4">
                 <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
                     <div className="space-y-2 text-center">
-                        <h1 className="text-2xl font-bold">Sign In</h1>
+                        <h1 className="text-2xl font-bold">{t('auth.signIn.title')}</h1>
                     </div>
                     <div className="space-y-2">
-                        <Label htmlFor="email">Email</Label>
+                        <Label htmlFor="email">{t('auth.signIn.emailLabel')}</Label>
                         <Input
                             id="email"
                             type="email"
@@ -183,7 +189,7 @@ const SignInPage = () => {
                         />
                     </div>
                     <div className="space-y-2">
-                        <Label htmlFor="password">Password</Label>
+                        <Label htmlFor="password">{t('auth.signIn.passwordLabel')}</Label>
                         <Input
                             id="password"
                             type="password"
@@ -193,7 +199,7 @@ const SignInPage = () => {
                         />
                     </div>
                     <Button type="submit" className="w-full" disabled={loading}>
-                        {loading ? 'Sign In...' : 'Sign In'}
+                        {loading ? t('auth.signIn.submitting') : t('auth.signIn.submit')}
                     </Button>
                     <Button
                         type="button"
@@ -203,7 +209,7 @@ const SignInPage = () => {
                         disabled={googleLoading || kakaoLoading}
                     >
                         <GoogleIcon className="h-5 w-5" />
-                        {googleLoading ? '구글로 로그인 중...' : '구글로 로그인'}
+                        {googleLoading ? t('auth.signIn.google.loading') : t('auth.signIn.google.start')}
                     </Button>
                     <Button
                         type="button"
@@ -213,11 +219,13 @@ const SignInPage = () => {
                         disabled={kakaoLoading || googleLoading}
                     >
                         <KakaoIcon className="h-5 w-5" />
-                        {kakaoLoading ? '카카오로 로그인 중...' : '카카오로 로그인'}
+                        {kakaoLoading ? t('auth.signIn.kakao.loading') : t('auth.signIn.kakao.start')}
                     </Button>
                     <div className="relative flex items-center">
                         <div className="flex-grow border-t border-gray-300" />
-                        <span className="mx-4 flex-shrink text-xs font-semibold tracking-wide text-muted-foreground">OR</span>
+                        <span className="mx-4 flex-shrink text-xs font-semibold tracking-wide text-muted-foreground">
+                            {t('common.or')}
+                        </span>
                         <div className="flex-grow border-t border-gray-300" />
                     </div>
                     <Button
@@ -227,12 +235,12 @@ const SignInPage = () => {
                         onClick={handleGuestLogin}
                         disabled={guestLoading}
                     >
-                        {guestLoading ? '게스트로 입장 중...' : '게스트로 둘러보기'}
+                        {guestLoading ? t('auth.signIn.guest.loading') : t('auth.signIn.guest.start')}
                     </Button>
                     <p className="text-sm text-center">
-                        Don&apos;t have an account?{' '}
+                        {t('auth.signIn.noAccount')} {' '}
                         <Link href="/sign_up" className="underline">
-                            Sign up
+                            {t('auth.signIn.signUpCta')}
                         </Link>
                     </p>
                 </form>

--- a/src/app/(auth)/sign_in/page.tsx
+++ b/src/app/(auth)/sign_in/page.tsx
@@ -160,7 +160,7 @@ const SignInPage = () => {
 
     return (
         <div className="flex min-h-screen">
-            <div className='absolute top-1 left-full flex translate-x-2 flex-col gap-1.5 sm:flex-row sm:translate-x-0'>
+            <div className='absolute top-1 right-1 flex flex-row'>
                 <LanguageToggle />
                 <DarkModeToggle />
             </div>

--- a/src/app/(auth)/sign_up/page.tsx
+++ b/src/app/(auth)/sign_up/page.tsx
@@ -8,15 +8,18 @@ import { toast } from 'sonner';
 import { userStore } from '@/stores/userStore';
 import { supabase } from '@/libs/supabaseClient';
 import DarkModeToggle from "@/components/DarkModeToggle";
+import LanguageToggle from "@/components/LanguageToggle";
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { useTranslations } from '@/providers/LanguageProvider';
 
 const SignUpPage = () => {
     const router = useRouter();
     const setApiKey = userStore((s) => s.setApiKey);
     const [form, setForm] = useState({ email: '', password: '', apiKey: '' });
     const [loading, setLoading] = useState(false);
+    const t = useTranslations();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -35,14 +38,17 @@ const SignUpPage = () => {
         if (apiKey) {
             setApiKey(apiKey);
         }
-        toast.success(`${form.email}로 인증 메일이 발송되었습니다. 확인해 주세요.`);
+        toast.success(t('auth.signUp.toast.verificationSent', { email: form.email }));
         router.push('/home');
         setLoading(false);
     };
 
     return (
         <div className="flex min-h-screen">
-            <DarkModeToggle className='absolute top-1 right-1'/>
+            <div className='absolute top-1 right-1 flex gap-1.5'>
+                <LanguageToggle />
+                <DarkModeToggle />
+            </div>
             <div className="relative hidden w-1/2 md:block">
                 <Image
                     src="/images/artwork_14.jpg"
@@ -55,10 +61,10 @@ const SignUpPage = () => {
             <div className="flex flex-1 items-center justify-center p-4">
                 <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
                     <div className="space-y-2 text-center">
-                        <h1 className="text-2xl font-bold">Sign Up</h1>
+                        <h1 className="text-2xl font-bold">{t('auth.signUp.title')}</h1>
                     </div>
                     <div className="space-y-2">
-                        <Label htmlFor="email">Email</Label>
+                        <Label htmlFor="email">{t('auth.signUp.emailLabel')}</Label>
                         <Input
                             id="email"
                             type="email"
@@ -68,7 +74,7 @@ const SignUpPage = () => {
                         />
                     </div>
                     <div className="space-y-2">
-                        <Label htmlFor="password">Password</Label>
+                        <Label htmlFor="password">{t('auth.signUp.passwordLabel')}</Label>
                         <Input
                             id="password"
                             type="password"
@@ -78,7 +84,7 @@ const SignUpPage = () => {
                         />
                     </div>
                     <div className="space-y-2">
-                        <Label htmlFor="apiKey">Nexon API Key</Label>
+                        <Label htmlFor="apiKey">{t('auth.signUp.apiKeyLabel')}</Label>
                         <Input
                             id="apiKey"
                             value={form.apiKey}
@@ -87,12 +93,12 @@ const SignUpPage = () => {
                         />
                     </div>
                     <Button type="submit" className="w-full" disabled={loading}>
-                        {loading ? 'Create account...' : 'Create account'}
+                        {loading ? t('auth.signUp.submitting') : t('auth.signUp.submit')}
                     </Button>
                     <p className="text-sm text-center">
-                        Already have an account?{' '}
+                        {t('auth.signUp.alreadyHave')} {' '}
                         <Link href="/sign_in" className="underline">
-                            Sign in
+                            {t('auth.signUp.signInCta')}
                         </Link>
                     </p>
                 </form>

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -10,9 +10,11 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { findCharacterBasic } from "@/fetchs/character.fetch";
 import { addFavorite, getFavorites, removeFavorite } from "@/fetchs/favorite.fetch";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import { useTranslations } from "@/providers/LanguageProvider";
 
 const Home = () => {
     const router = useRouter();
+    const t = useTranslations();
     const [user, setUser] = useState<{ id: string; email?: string } | null>(null);
     const [favorites, setFavorites] = useState<ICharacterSummary[]>([]);
     const { setFavorites: setFavoriteOcids, addFavorite: addFavoriteOcid, removeFavorite: removeFavoriteOcid } = favoriteStore();
@@ -123,7 +125,7 @@ const Home = () => {
                             rounded-2xl bg-background p-0 shadow-lg
                         "
                     >
-                        <DialogTitle className="px-4 pt-4">Info</DialogTitle>
+                        <DialogTitle className="px-4 pt-4">{t('home.dialog.title')}</DialogTitle>
                         <CharacterInfo
                             ocid={selected}
                             goToDetailPage={goToDetailPage}

--- a/src/app/(main)/search/page.tsx
+++ b/src/app/(main)/search/page.tsx
@@ -8,17 +8,19 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { findCharacterId } from '@/fetchs/character.fetch';
+import { useTranslations } from '@/providers/LanguageProvider';
 
 const SearchPage = () => {
     const router = useRouter();
     const [query, setQuery] = useState('');
     const [loading, setLoading] = useState(false);
+    const t = useTranslations();
 
     const handleSearch = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         const trimmed = query.trim();
         if (!trimmed) {
-            toast.error('캐릭터 이름을 입력해주세요.');
+            toast.error(t('search.errors.empty'));
             return;
         }
 
@@ -27,14 +29,19 @@ const SearchPage = () => {
             const response = await findCharacterId(trimmed);
             const ocid = response.data.ocid;
             if (!ocid) {
-                toast.error('캐릭터를 찾을 수 없습니다. 이름을 확인해주세요.');
+                toast.error(t('search.errors.notFound'));
                 return;
             }
             router.push(`/character/${ocid}`);
         } catch (error) {
-            let message = '캐릭터를 찾을 수 없습니다. 이름을 확인해주세요.';
-             if (error instanceof Error) {
-                message = error.message;
+            const defaultMessage = t('search.errors.notFound');
+            let message = defaultMessage;
+            if (error instanceof Error && error.message) {
+                if (error.message === '캐릭터를 찾을 수 없습니다. 이름을 확인해주세요.') {
+                    message = defaultMessage;
+                } else {
+                    message = error.message;
+                }
             }
             toast.error(message);
         } finally {
@@ -47,9 +54,9 @@ const SearchPage = () => {
             <div className="flex w-full max-w-2xl flex-col items-center gap-8">
                 <div className="flex flex-col items-center gap-3 text-center">
                     <Image src="/Reheln.png" alt="Finder" width={96} height={96} priority />
-                    <h1 className="text-3xl font-semibold tracking-tight">Search</h1>
+                    <h1 className="text-3xl font-semibold tracking-tight">{t('search.heading')}</h1>
                     <p className="max-w-lg text-balance text-sm text-muted-foreground">
-                        원하는 캐릭터를 찾아 상세 정보를 확인할 수 있습니다.
+                        {t('search.description')}
                     </p>
                 </div>
                 <form onSubmit={handleSearch} className="w-full space-y-6">
@@ -58,7 +65,7 @@ const SearchPage = () => {
                         <Input
                             value={query}
                             onChange={(event) => setQuery(event.target.value)}
-                            placeholder="캐릭터 이름을 검색하세요"
+                            placeholder={t('search.placeholder')}
                             autoComplete="off"
                             autoFocus
                             className="flex-1 border-0 bg-transparent p-0 text-lg shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
@@ -73,10 +80,10 @@ const SearchPage = () => {
                             {loading ? (
                                 <>
                                     <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-                                    검색 중...
+                                    {t('search.loading')}
                                 </>
                             ) : (
-                                'Search'
+                                t('search.button')
                             )}
                         </Button>
                     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { AuthProvider } from "@/providers/AuthProvider";
+import { LanguageProvider } from "@/providers/LanguageProvider";
 
 const mapleStory = localFont({
     src: [
@@ -54,10 +55,12 @@ const RootLayout = ({ children }: Readonly<{ children: ReactNode }>) => {
             strategy="afterInteractive"
         />
 
-        <AuthProvider>
-            <ViewTransition enter="fade" exit="fade">{children}</ViewTransition>
-            <Toaster />
-        </AuthProvider>
+        <LanguageProvider>
+            <AuthProvider>
+                <ViewTransition enter="fade" exit="fade">{children}</ViewTransition>
+                <Toaster />
+            </AuthProvider>
+        </LanguageProvider>
         </body>
         </html>
     );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,38 +1,40 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight, Compass, Home, Search, Sparkles } from "lucide-react";
 import DarkModeToggle from "@/components/DarkModeToggle";
+import LanguageToggle from "@/components/LanguageToggle";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslations } from "@/providers/LanguageProvider";
 
 const SUGGESTIONS = [
     {
-        title: "랜딩으로 이동",
-        description: "Finder 소개 페이지에서 제공하는 주요 기능과 소식을 확인해 보세요.",
+        key: "landing" as const,
         href: "/",
-        cta: "메인 살펴보기",
         Icon: Compass,
     },
     {
-        title: "캐릭터 검색",
-        description: "월드와 닉네임만 입력하면 실시간으로 캐릭터 정보를 확인할 수 있어요.",
+        key: "search" as const,
         href: "/search",
-        cta: "바로 검색하기",
         Icon: Search,
     },
     {
-        title: "즐겨찾기 관리",
-        description: "로그인 후 자주 보는 캐릭터를 저장하고 한곳에서 관리해 보세요.",
+        key: "favorites" as const,
         href: "/home",
-        cta: "즐겨찾기 이동",
         Icon: Sparkles,
     },
 ] as const;
 
 const NotFound = () => {
+    const t = useTranslations();
     return (
         <main className="relative flex min-h-[100dvh] flex-col overflow-hidden bg-background text-foreground">
-            <DarkModeToggle className="absolute right-3 top-3 z-20 sm:right-6 sm:top-6" />
+            <div className="absolute right-3 top-3 z-20 flex gap-1.5 sm:right-6 sm:top-6">
+                <LanguageToggle />
+                <DarkModeToggle />
+            </div>
 
             <div
                 aria-hidden
@@ -49,7 +51,7 @@ const NotFound = () => {
                         <div className="absolute -inset-10 rounded-full bg-primary/10 blur-3xl dark:bg-primary/20" />
                         <Image
                             src="/Reheln.png"
-                            alt="MapleStory Finder"
+                            alt={t('common.appName')}
                             width={112}
                             height={112}
                             className="relative z-10 h-24 w-24 rounded-3xl border border-border/60 bg-background/90 p-4 shadow-lg shadow-primary/20 backdrop-blur"
@@ -60,28 +62,28 @@ const NotFound = () => {
                     </span>
                     <div className="space-y-4 sm:space-y-5">
                         <h1 className="text-pretty text-3xl font-semibold leading-tight tracking-tight sm:text-4xl">
-                            찾으시던 페이지를 발견하지 못했어요
+                            {t('notFound.title')}
                         </h1>
                         <p className="mx-auto max-w-2xl text-sm text-muted-foreground sm:text-base">
-                            입력하신 주소가 잘못되었거나 페이지가 이동되었을 수 있어요. 아래의 추천 경로로 이동하거나 검색을 이용해 원하시는 정보를 다시 찾아보세요.
+                            {t('notFound.description')}
                         </p>
                     </div>
                 </div>
 
                 <div className="grid w-full gap-4 text-left sm:grid-cols-2 lg:grid-cols-3">
-                    {SUGGESTIONS.map(({ title, description, href, cta, Icon }) => (
-                        <Card key={title} className="border-border/60 bg-background/80 backdrop-blur">
+                    {SUGGESTIONS.map(({ key, href, Icon }) => (
+                        <Card key={key} className="border-border/60 bg-background/80 backdrop-blur">
                             <CardHeader className="gap-3">
                                 <div className="flex items-center gap-3">
                                     <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-border/60 bg-muted/60">
                                         <Icon className="h-5 w-5 text-primary" strokeWidth={1.8} />
                                     </span>
                                     <CardTitle className="text-base font-semibold text-foreground">
-                                        {title}
+                                        {t(`notFound.suggestions.${key}.title`)}
                                     </CardTitle>
                                 </div>
                                 <CardDescription className="leading-relaxed text-sm text-muted-foreground">
-                                    {description}
+                                    {t(`notFound.suggestions.${key}.description`)}
                                 </CardDescription>
                             </CardHeader>
                             <CardContent className="pt-0">
@@ -91,7 +93,7 @@ const NotFound = () => {
                                     className="gap-2 px-0 text-sm font-semibold text-primary hover:bg-transparent hover:text-primary"
                                 >
                                     <Link href={href}>
-                                        {cta}
+                                        {t(`notFound.suggestions.${key}.cta`)}
                                         <ArrowRight className="h-4 w-4" />
                                     </Link>
                                 </Button>
@@ -104,13 +106,13 @@ const NotFound = () => {
                     <Button asChild className="gap-2">
                         <Link href="/">
                             <Home className="h-4 w-4" />
-                            메인으로 돌아가기
+                            {t('notFound.actions.home')}
                         </Link>
                     </Button>
                     <Button asChild variant="outline" className="gap-2">
                         <Link href="/search">
                             <Search className="h-4 w-4" />
-                            캐릭터 검색하기
+                            {t('notFound.actions.search')}
                         </Link>
                     </Button>
                 </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,23 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { unstable_ViewTransition as ViewTransition } from "react";
 import { ArrowRight, BarChart3, Bot, type LucideIcon, Search, ShieldCheck, Sparkles, Wand2, } from "lucide-react";
 import DarkModeToggle from "@/components/DarkModeToggle";
+import LanguageToggle from "@/components/LanguageToggle";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslations } from "@/providers/LanguageProvider";
 
 const Page = () => {
+    const t = useTranslations();
     return (
         <ViewTransition enter="fade" exit="fade">
-            <DarkModeToggle className='absolute top-1 right-1 z-10'/>
+            <div className='absolute top-1 right-1 z-10 flex gap-1.5'>
+                <LanguageToggle />
+                <DarkModeToggle />
+            </div>
             <main className="bg-background text-foreground">
                 <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-16 px-4 pb-16 pt-12 sm:px-6 lg:px-8 space-y-6">
                     <section className="grid gap-10 md:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] md:items-center">
@@ -18,30 +26,30 @@ const Page = () => {
                                 className="inline-flex items-center gap-2 rounded-full border border-border bg-muted/70 px-4 py-1 text-xs font-medium uppercase tracking-[0.32em] text-muted-foreground">
                                 <Image
                                     src="/Reheln.png"
-                                    alt="MapleStory Finder"
+                                    alt={t('common.appName')}
                                     className="object-contain"
                                     width={20}
                                     height={20}
                                     priority
                                 />
-                                MapleStory Finder
+                                {t('common.appName')}
                             </div>
                             <h1 className="text-balance text-4xl font-semibold leading-tight break-keep tracking-tight sm:text-5xl">
-                                내 캐릭터를 한눈에 정리해 보여주는 『Finder』
+                                {t('landing.hero.title')}
                             </h1>
                             <p className="max-w-2xl text-base text-muted-foreground sm:text-lg mb-10">
-                                실시간 캐릭터 검색부터 스탯 요약, AI 챗봇, 피규어 생성까지 MapleStory Finder에서 모두 이용해 보세요. 다른 페이지와 어우러지는 깔끔한 레이아웃으로 주요 기능을 빠르게 확인할 수 있습니다.
+                                {t('landing.hero.description')}
                             </p>
                             <div className="flex flex-col gap-3 sm:flex-row">
                                 <Button asChild className="gap-2">
                                     <Link href="/sign_in">
-                                        지금 시작하기
+                                        {t('landing.hero.ctaPrimary')}
                                         <ArrowRight className="h-4 w-4"/>
                                     </Link>
                                 </Button>
                                 <Button asChild variant="outline" className="gap-2">
                                     <Link href="/search">
-                                        캐릭터 검색
+                                        {t('landing.hero.ctaSecondary')}
                                         <Search className="h-4 w-4"/>
                                     </Link>
                                 </Button>
@@ -51,17 +59,17 @@ const Page = () => {
                         <Card className="h-full border-border/70 bg-card/90 shadow-sm">
                             <CardHeader>
                                 <CardTitle className="text-lg font-semibold flex gap-2 items-baseline">
-                                    <Sparkles className="h-4 w-4 text-primary mb-0.5"/> Finder 미리보기
+                                    <Sparkles className="h-4 w-4 text-primary mb-0.5"/> {t('landing.preview.title')}
                                 </CardTitle>
                                 <CardDescription>
-                                    Finder에서 내 캐릭터를 검색해보세요.
+                                    {t('landing.preview.description')}
                                 </CardDescription>
                             </CardHeader>
                             <CardContent className="flex flex-col gap-6 pb-8">
                                 <div className="relative mx-auto aspect-square w-40 overflow-hidden rounded-2xl bg-muted sm:w-56">
                                     <Image
                                         src="/images/preview/character_detail.png"
-                                        alt="MapleStory Finder"
+                                        alt={t('common.appName')}
                                         fill
                                         className="object-contain px-2 block dark:hidden"
                                         sizes="(max-width: 768px) 10rem, 14rem"
@@ -69,7 +77,7 @@ const Page = () => {
                                     />
                                     <Image
                                         src="/images/preview/character_detail_dark.png"
-                                        alt="MapleStory Finder"
+                                        alt={t('common.appName')}
                                         fill
                                         className="object-contain px-2 hidden dark:block"
                                         sizes="(max-width: 768px) 10rem, 14rem"
@@ -77,48 +85,58 @@ const Page = () => {
                                     />
                                 </div>
                                 <div className="grid gap-3 text-sm text-muted-foreground sm:grid-cols-2">
-                                    <div
-                                        className="rounded-lg border border-dashed border-border/70 bg-background/70 p-4
-                                            transition-transform duration-300 ease-out hover:-translate-y-2 hover:shadow-lg hover:shadow-primary/20">
-                                        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">캐릭터</p>
-                                        <p className="mt-1 text-base font-semibold text-foreground">실시간 검색</p>
-                                        <p className="mt-1 text-xs text-muted-foreground">닉네임과 월드만 입력하면 기본 정보와 스탯을 즉시 확인할 수 있습니다.</p>
-                                    </div>
-                                    <div
-                                        className="rounded-lg border border-dashed border-border/70 bg-background/70 p-4
-                                            transition-transform duration-300 ease-out hover:-translate-y-2 hover:shadow-lg hover:shadow-primary/20">
-                                        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">인사이트</p>
-                                        <p className="mt-1 text-base font-semibold text-foreground">AI 도우미</p>
-                                        <p className="mt-1 text-xs text-muted-foreground">AI가 전투력, 장비 구성 등 궁금한 내용을 대화로 안내합니다.</p>
-                                    </div>
+                                    {PREVIEW_CARDS.map(({ key }) => (
+                                        <div
+                                            key={key}
+                                            className="rounded-lg border border-dashed border-border/70 bg-background/70 p-4 transition-transform duration-300 ease-out hover:-translate-y-2 hover:shadow-lg hover:shadow-primary/20"
+                                        >
+                                            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">
+                                                {t(`landing.preview.cards.${key}.label`)}
+                                            </p>
+                                            <p className="mt-1 text-base font-semibold text-foreground">
+                                                {t(`landing.preview.cards.${key}.title`)}
+                                            </p>
+                                            <p className="mt-1 text-xs text-muted-foreground">
+                                                {t(`landing.preview.cards.${key}.description`)}
+                                            </p>
+                                        </div>
+                                    ))}
                                 </div>
                             </CardContent>
                         </Card>
                     </section>
 
                     <section className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-                        {HIGHLIGHTS.map(({ Icon, title, description }) => (
+                        {HIGHLIGHTS.map(({ key, Icon }) => (
                             <Card
-                                key={title}
+                                key={key}
                                 className="border-border/70 transition-transform duration-300 ease-out hover:-translate-y-2 hover:shadow-lg hover:shadow-primary/20"
                             >
                                 <CardContent className="flex flex-col gap-4 py-6">
                                     <Icon className="h-10 w-10 text-primary" strokeWidth={1.6}/>
-                                    <h3 className="text-lg font-semibold text-foreground">{title}</h3>
-                                    <p className="text-sm text-muted-foreground">{description}</p>
+                                    <h3 className="text-lg font-semibold text-foreground">
+                                        {t(`landing.highlights.${key}.title`)}
+                                    </h3>
+                                    <p className="text-sm text-muted-foreground">
+                                        {t(`landing.highlights.${key}.description`)}
+                                    </p>
                                 </CardContent>
                             </Card>
                         ))}
                     </section>
 
                     <section className="grid gap-4 md:grid-cols-2">
-                        {QUICK_LINKS.map(({ title, description, href, cta, Icon }) => (
-                            <Card key={title} className="border-border/70 bg-muted/40">
+                        {QUICK_LINKS.map(({ key, href, Icon }) => (
+                            <Card key={key} className="border-border/70 bg-muted/40">
                                 <CardContent className="flex h-full flex-col gap-4 py-6">
                                     <div className="flex items-start justify-between gap-3">
                                         <div className="space-y-1">
-                                            <p className="text-sm font-semibold text-foreground">{title}</p>
-                                            <p className="text-sm text-muted-foreground">{description}</p>
+                                            <p className="text-sm font-semibold text-foreground">
+                                                {t(`landing.quickLinks.${key}.title`)}
+                                            </p>
+                                            <p className="text-sm text-muted-foreground">
+                                                {t(`landing.quickLinks.${key}.description`)}
+                                            </p>
                                         </div>
                                         <Icon className="h-5 w-5 text-primary" strokeWidth={1.6}/>
                                     </div>
@@ -128,7 +146,7 @@ const Page = () => {
                                         className="w-fit gap-2 px-0 text-sm font-semibold text-primary hover:bg-transparent hover:text-primary"
                                     >
                                         <Link href={href}>
-                                            {cta}
+                                            {t(`landing.quickLinks.${key}.cta`)}
                                             <ArrowRight className="h-4 w-4"/>
                                         </Link>
                                     </Button>
@@ -142,51 +160,50 @@ const Page = () => {
     );
 };
 
+type PreviewCard = {
+    key: "character" | "insight";
+};
+
 type Feature = {
-    title: string;
-    description: string;
+    key: "search" | "stats" | "equipment";
     Icon: LucideIcon;
 };
 
 type QuickLink = {
-    title: string;
-    description: string;
+    key: "chat" | "figure";
     href: string;
-    cta: string;
     Icon: LucideIcon;
 };
 
+const PREVIEW_CARDS: PreviewCard[] = [
+    { key: "character" },
+    { key: "insight" },
+];
+
 const HIGHLIGHTS: Feature[] = [
     {
-        title: "실시간 캐릭터 검색",
-        description: "닉네임과 월드만 입력하면 원하는 캐릭터를 빠르게 찾아 주요 정보를 확인할 수 있습니다.",
+        key: "search",
         Icon: Search,
     },
     {
-        title: "한눈에 보는 스탯 리포트",
-        description: "공격력, 보스 대미지, 크리티컬 등 핵심 스탯을 자동으로 정리해 제공합니다.",
+        key: "stats",
         Icon: BarChart3,
     },
     {
-        title: "장비와 아이템 체크",
-        description: "현재 착용 중인 장비와 주요 옵션을 깔끔한 카드 형식으로 살펴볼 수 있습니다.",
+        key: "equipment",
         Icon: ShieldCheck,
     },
 ];
 
 const QUICK_LINKS: QuickLink[] = [
     {
-        title: "Gemini AI 챗봇",
-        description: "메이플스토리 데이터를 기반으로 질문에 답하는 대화형 인터페이스를 사용해 보세요.",
+        key: "chat",
         href: "/chat",
-        cta: "챗봇 열기",
         Icon: Bot,
     },
     {
-        title: "캐릭터 피규어 생성",
-        description: "AI가 캐릭터 이미지를 바탕으로 3D 피규어 렌더를 생성해 드립니다. 캐릭터 상세에서 바로 이동하세요.",
+        key: "figure",
         href: "/figure",
-        cta: "피규어 페이지로",
         Icon: Wand2,
     },
 ];

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -2,6 +2,8 @@
 
 import { Moon, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useTranslations } from '@/providers/LanguageProvider';
+import { cn } from '@/utils/utils';
 
 type DocumentWithViewTransition = Document & {
     startViewTransition?: (callback: () => void | Promise<void>) => void;
@@ -14,6 +16,7 @@ interface IDarkModeToggle {
 }
 
 const DarkModeToggle = ({ className }: IDarkModeToggle) => {
+    const t = useTranslations();
     const toggleTheme = () => {
         const root = document.documentElement;
         const nextIsDark = !root.classList.contains('dark');
@@ -68,8 +71,8 @@ const DarkModeToggle = ({ className }: IDarkModeToggle) => {
             variant="ghost"
             size="sm"
             onClick={toggleTheme}
-            aria-label="Toggle dark mode"
-            className={`hover:bg-transparent ${className}`}
+            aria-label={t('common.darkModeToggle.ariaLabel')}
+            className={cn('hover:bg-transparent', className)}
         >
             <Sun className="h-5 w-5 text-foreground hidden dark:block"/>
             <Moon className="h-5 w-5 text-foreground block dark:hidden"/>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import DarkModeToggle from '@/components/DarkModeToggle';
+import LanguageToggle from '@/components/LanguageToggle';
 import SideMenu from '@/components/SideMenu';
 import { useAuth } from '@/providers/AuthProvider';
 
@@ -21,7 +22,8 @@ const Header = () => {
         <Image src="/Reheln.png" alt="Finder" width={40} height={40} priority />
       </Link>
       {/* 오른쪽 메뉴 */}
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center gap-1.5">
+        <LanguageToggle />
         <DarkModeToggle />
         <SideMenu />
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ const Header = () => {
         <Image src="/Reheln.png" alt="Finder" width={40} height={40} priority />
       </Link>
       {/* 오른쪽 메뉴 */}
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center">
         <LanguageToggle />
         <DarkModeToggle />
         <SideMenu />

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useLanguage, useTranslations } from "@/providers/LanguageProvider";
+import { cn } from "@/utils/utils";
+
+interface LanguageToggleProps {
+    className?: string;
+}
+
+const LanguageToggle = ({ className }: LanguageToggleProps) => {
+    const { language, toggleLanguage } = useLanguage();
+    const t = useTranslations();
+    const labelKey =
+        language === "en" ? "common.languageToggle.short.en" : "common.languageToggle.short.ko";
+    const label = t(labelKey);
+
+    return (
+        <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleLanguage}
+            aria-label={t("common.languageToggle.ariaLabel")}
+            className={cn("hover:bg-transparent", className)}
+        >
+            <span className="text-sm font-semibold tracking-wide">{label}</span>
+        </Button>
+    );
+};
+
+export default LanguageToggle;

--- a/src/components/character/CharacterBanner.tsx
+++ b/src/components/character/CharacterBanner.tsx
@@ -11,6 +11,7 @@ import { ICharacterBasic, ICharacterDojang, ICharacterPopularity } from "@/inter
 import { IGuildBasic } from "@/interface/guild/IGuild";
 import { IUnion } from "@/interface/union/IUnion";
 import { useAuth } from "@/providers/AuthProvider";
+import { useTranslations } from "@/providers/LanguageProvider";
 import { cn } from "@/utils/utils";
 
 type CharacterBannerProps = {
@@ -46,6 +47,7 @@ const CharacterBanner = ({
 }: CharacterBannerProps) => {
     const router = useRouter();
     const { status } = useAuth();
+    const t = useTranslations();
     const bannerImageSrc = imageSrc ?? (basic?.character_image
         ? `/api/crop?url=${encodeURIComponent(basic.character_image)}`
         : null
@@ -108,25 +110,33 @@ const CharacterBanner = ({
                             </div>
                         </div>
                         <div className="absolute top-2 left-1/2 -translate-x-1/2 bg-muted px-2 py-1 rounded-md text-sm font-medium z-10">
-                            Lv. {basic.character_level}
+                            {t('common.level', { value: basic.character_level })}
                         </div>
                         <div className="absolute top-2 right-2 bg-muted px-2 py-1 rounded-md text-sm font-medium z-10">
                             {basic.character_class}
                         </div>
                         <div className="absolute bottom-12 left-2 space-y-2 text-sm z-10">
                             {union && (
-                                <div className="bg-muted px-2 py-1 rounded-md">유니온 {union.union_level}</div>
+                                <div className="bg-muted px-2 py-1 rounded-md">
+                                    {t('character.banner.union', { level: union.union_level })}
+                                </div>
                             )}
                             {dojang && (
-                                <div className="bg-muted px-2 py-1 rounded-md">무릉 {dojang.dojang_best_floor}층</div>
+                                <div className="bg-muted px-2 py-1 rounded-md">
+                                    {t('character.banner.dojang', { floor: dojang.dojang_best_floor })}
+                                </div>
                             )}
                             {popularity && (
-                                <div className="bg-muted px-2 py-1 rounded-md ">인기도 {popularity.popularity}</div>
+                                <div className="bg-muted px-2 py-1 rounded-md ">
+                                    {t('character.banner.popularity', { value: popularity.popularity })}
+                                </div>
                             )}
                         </div>
                         <div className="absolute bottom-12 right-2 space-y-2 text-sm z-10">
                             {guild?.guild_name && (
-                                <div className="bg-muted px-2 py-1 rounded-md">길드 {guild.guild_name}</div>
+                                <div className="bg-muted px-2 py-1 rounded-md">
+                                    {t('character.banner.guild', { name: guild.guild_name })}
+                                </div>
                             )}
                             {status !== 'guest' &&
                                 <div className="bg-muted px-2 py-1 rounded-md flex items-center gap-1 hover:cursor-pointer" onClick={() => getFigure()}>
@@ -136,11 +146,11 @@ const CharacterBanner = ({
                                                 className=" bg-muted rounded-md flex items-center gap-2 hover:cursor-pointer"
                                                 onClick={() => getFigure()}
                                             >
-                                                피규어 <SquareArrowOutUpRight size={14}/>
+                                                {t('character.banner.figure')} <SquareArrowOutUpRight size={14}/>
                                             </div>
                                         </TooltipTrigger>
                                         <TooltipContent>
-                                            아직 미완성 기능입니다
+                                            {t('character.banner.figureTooltip')}
                                         </TooltipContent>
                                     </Tooltip>
                                 </div>

--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -33,6 +33,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { findCharacterAbility, findCharacterAndroidEquipment, findCharacterBasic, findCharacterBeautyEquipment, findCharacterCashItemEquipment, findCharacterDojang, findCharacterHexaMatrix, findCharacterHexaMatrixStat, findCharacterHyperStat, findCharacterItemEquipment, findCharacterLinkSkill, findCharacterOtherStat, findCharacterPetEquipment, findCharacterPopularity, findCharacterPropensity, findCharacterRingExchange, findCharacterSetEffect, findCharacterSkill, findCharacterStat, findCharacterSymbolEquipment, findCharacterVMatrix, } from "@/fetchs/character.fetch";
 import { findGuildBasic, findGuildId } from "@/fetchs/guild.fetch";
 import { findUnion, findUnionArtifact, findUnionRaider } from "@/fetchs/union.fetch";
+import { useTranslations } from "@/providers/LanguageProvider";
 
 const CharacterDetail = ({ ocid }: { ocid: string }) => {
     const {
@@ -48,6 +49,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
         setBeauty, setAndroid, setPet, setPropensity, setAbility,
         reset,
     } = characterDetailStore();
+    const t = useTranslations();
     const [imageScale, setImageScale] = useState(1);
     const [basicLoading, setBasicLoading] = useState(true);
     const [tab, setTab] = useState("basic");
@@ -114,7 +116,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
             } catch (e) {
                 if (!cancelled) {
                     console.error(e);
-                    toast.error('캐릭터 정보 로딩 실패');
+                    toast.error(t('character.detail.toast.loadCharacter'));
                 }
             } finally {
                 if (!cancelled) {
@@ -158,7 +160,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                 setUnionArtifact(artifactRes.data);
             } catch (e) {
                 console.error(e);
-                toast.error('유니온 정보 로딩 실패');
+                toast.error(t('character.detail.toast.loadUnion'));
             }
         };
         loadUnion();
@@ -179,7 +181,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                 setSetEffect(setEffectRes.data);
             } catch (e) {
                 console.error(e);
-                toast.error('장비 정보 로딩 실패');
+                toast.error(t('character.detail.toast.loadEquip'));
             }
         };
         loadEquip();
@@ -211,7 +213,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                 setVMatrix(vMatrixRes.data);
             } catch (e) {
                 console.error(e);
-                toast.error('스킬 정보 로딩 실패');
+                toast.error(t('character.detail.toast.loadSkill'));
             }
         };
         loadSkill();
@@ -247,7 +249,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                 setPet(petRes.data);
             } catch (e) {
                 console.error(e);
-                toast.error('캐시 정보 로딩 실패');
+                toast.error(t('character.detail.toast.loadCash'));
             }
         };
         loadCash();
@@ -275,7 +277,7 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                 setPropensity(propensityRes.data);
             } catch (e) {
                 console.error(e);
-                toast.error('기타 정보 로딩 실패');
+                toast.error(t('character.detail.toast.loadEtc'));
             }
         };
         loadEtc();
@@ -369,12 +371,12 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                                     className="order-2 w-full sm:order-1 sm:flex-1"
                                 >
                                     <TabsList className="flex flex-wrap gap-2 sm:flex-nowrap sm:gap-0 sm:space-x-2">
-                                        <TabsTrigger value="basic">기본 정보</TabsTrigger>
-                                        <TabsTrigger value="union">유니온</TabsTrigger>
-                                        <TabsTrigger value="equip">장비</TabsTrigger>
-                                        <TabsTrigger value="skill">스킬</TabsTrigger>
-                                        <TabsTrigger value="cash">캐시</TabsTrigger>
-                                        <TabsTrigger value="etc">기타</TabsTrigger>
+                                        <TabsTrigger value="basic">{t('character.detail.tabs.basic')}</TabsTrigger>
+                                        <TabsTrigger value="union">{t('character.detail.tabs.union')}</TabsTrigger>
+                                        <TabsTrigger value="equip">{t('character.detail.tabs.equip')}</TabsTrigger>
+                                        <TabsTrigger value="skill">{t('character.detail.tabs.skill')}</TabsTrigger>
+                                        <TabsTrigger value="cash">{t('character.detail.tabs.cash')}</TabsTrigger>
+                                        <TabsTrigger value="etc">{t('character.detail.tabs.etc')}</TabsTrigger>
                                     </TabsList>
                                 </Tabs>
                             </div>

--- a/src/components/home/CharacterInfo.tsx
+++ b/src/components/home/CharacterInfo.tsx
@@ -10,6 +10,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { findCharacterBasic, findCharacterItemEquipment } from "@/fetchs/character.fetch";
 import { ICharacterBasic, IItemEquipment } from "@/interface/character/ICharacter";
+import { useTranslations } from "@/providers/LanguageProvider";
 import { cn } from "@/utils/utils";
 
 interface ICharacterInfoProps {
@@ -21,6 +22,7 @@ interface ICharacterInfoProps {
 const CharacterInfo = ({ ocid, goToDetailPage, className }: ICharacterInfoProps) => {
     const [basic, setBasic] = useState<ICharacterBasic | null>(null);
     const [items, setItems] = useState<IItemEquipment[]>([]);
+    const t = useTranslations();
     const [loading, setLoading] = useState(false);
     const setPreview = useCharacterPreviewStore((state) => state.setPreview);
     const clearPreview = useCharacterPreviewStore((state) => state.clear);
@@ -72,7 +74,7 @@ const CharacterInfo = ({ ocid, goToDetailPage, className }: ICharacterInfoProps)
         <ScrollArea className={cn("hidden md:flex flex-1", className)}>
             {!ocid ? (
                 <div className="flex justify-center items-center w-full h-page animate-pulse">
-                    Please choose your character
+                    {t('home.characterInfo.emptyState')}
                 </div>
             ) : (
                 <div className="p-4 max-w-6xl mx-auto">
@@ -140,7 +142,7 @@ const CharacterInfo = ({ ocid, goToDetailPage, className }: ICharacterInfoProps)
                                 {loading || !basic ? (
                                     <Skeleton className="h-10 w-20" />
                                 ) : (
-                                    <Button onClick={goToDetailPage}>Detail</Button>
+                                    <Button onClick={goToDetailPage}>{t('home.characterInfo.detailButton')}</Button>
                                 )}
                             </div>
                         </section>

--- a/src/constants/i18n/translations.ts
+++ b/src/constants/i18n/translations.ts
@@ -1,0 +1,455 @@
+export const translations = {
+    en: {
+        common: {
+            appName: "MapleStory Finder",
+            languageToggle: {
+                ariaLabel: "Toggle language",
+                short: {
+                    en: "EN",
+                    ko: "KO",
+                },
+                english: "EN",
+                korean: "KO",
+            },
+            darkModeToggle: {
+                ariaLabel: "Toggle dark mode",
+            },
+            loading: "Loading...",
+            level: "Lv. {value}",
+            info: "Info",
+            detail: "Detail",
+            search: "Search",
+            or: "OR",
+            home: "Home",
+            backToHome: "Back to main",
+            characterSearch: "Character Search",
+            findCharacter: "Search characters",
+            guest: "Guest",
+        },
+        search: {
+            heading: "Search",
+            description: "Find the character you want and explore their details.",
+            placeholder: "Search for a character name",
+            errors: {
+                empty: "Please enter a character name.",
+                notFound: "Character not found. Please check the name.",
+            },
+            loading: "Searching...",
+            button: "Search",
+        },
+        auth: {
+            signIn: {
+                title: "Sign In",
+                emailLabel: "Email",
+                passwordLabel: "Password",
+                submit: "Sign In",
+                submitting: "Signing in...",
+                google: {
+                    start: "Continue with Google",
+                    loading: "Signing in with Google...",
+                },
+                kakao: {
+                    start: "Continue with Kakao",
+                    loading: "Signing in with Kakao...",
+                },
+                guest: {
+                    start: "Browse as guest",
+                    loading: "Entering as guest...",
+                },
+                noAccount: "Don't have an account?",
+                signUpCta: "Sign up",
+                toast: {
+                    success: "Signed in successfully.",
+                    guestSuccess: "Signed in as guest.",
+                    googleError: "There was a problem with Google sign-in.",
+                    kakaoError: "There was a problem with Kakao sign-in.",
+                },
+            },
+            signUp: {
+                title: "Sign Up",
+                emailLabel: "Email",
+                passwordLabel: "Password",
+                apiKeyLabel: "Nexon API Key",
+                submit: "Create account",
+                submitting: "Creating account...",
+                alreadyHave: "Already have an account?",
+                signInCta: "Sign in",
+                toast: {
+                    verificationSent: "A verification email has been sent to {email}. Please check your inbox.",
+                },
+            },
+        },
+        landing: {
+            hero: {
+                title: "Finder shows your characters at a glance",
+                description:
+                    "From real-time character search to stat summaries, the AI chatbot, and figure generation, explore every feature of MapleStory Finder in one clean layout.",
+                ctaPrimary: "Get started now",
+                ctaSecondary: "Search characters",
+            },
+            preview: {
+                title: "Finder preview",
+                description: "Search for your character in Finder.",
+                cards: {
+                    character: {
+                        label: "Character",
+                        title: "Real-time search",
+                        description:
+                            "Check basic information and stats instantly by entering only the nickname and world.",
+                    },
+                    insight: {
+                        label: "Insights",
+                        title: "AI assistant",
+                        description:
+                            "Ask the AI about combat power, gear loadouts, and anything else you're curious about.",
+                    },
+                },
+            },
+            highlights: {
+                search: {
+                    title: "Real-time character search",
+                    description:
+                        "Quickly find the character you want and review key information with just a nickname and world.",
+                },
+                stats: {
+                    title: "Stat report at a glance",
+                    description:
+                        "Attack, boss damage, critical rate, and other core stats are organized automatically.",
+                },
+                equipment: {
+                    title: "Gear and item check",
+                    description:
+                        "Review equipped gear and major options in tidy, card-based layouts.",
+                },
+            },
+            quickLinks: {
+                chat: {
+                    title: "Gemini AI chatbot",
+                    description:
+                        "Use the conversational interface powered by MapleStory data to get answers to your questions.",
+                    cta: "Open chatbot",
+                },
+                figure: {
+                    title: "Character figure generator",
+                    description:
+                        "Let AI render a 3D figure based on your character image. Jump in directly from the character detail page.",
+                    cta: "Go to figure page",
+                },
+            },
+        },
+        notFound: {
+            title: "We couldn't find the page you were looking for",
+            description:
+                "The address you entered may be incorrect or the page may have moved. Try one of the recommended paths below or use search to find what you need.",
+            suggestions: {
+                landing: {
+                    title: "Go to the landing page",
+                    description: "Check the main features and updates introduced on the Finder overview page.",
+                    cta: "Browse the main page",
+                },
+                search: {
+                    title: "Character search",
+                    description: "Enter the world and nickname to view character information in real time.",
+                    cta: "Search now",
+                },
+                favorites: {
+                    title: "Manage favorites",
+                    description: "After signing in, save frequently viewed characters and manage them in one place.",
+                    cta: "Go to favorites",
+                },
+            },
+            actions: {
+                home: "Back to main",
+                search: "Search for characters",
+            },
+        },
+        home: {
+            characterInfo: {
+                emptyState: "Please choose your character",
+                detailButton: "Detail",
+            },
+            dialog: {
+                title: "Info",
+            },
+        },
+        authProvider: {
+            toast: {
+                logout: "You have been logged out.",
+                loginRequired: "Please sign in to use this service.",
+            },
+        },
+        character: {
+            detail: {
+                tabs: {
+                    basic: "Basic",
+                    union: "Union",
+                    equip: "Equipment",
+                    skill: "Skills",
+                    cash: "Cash",
+                    etc: "Other",
+                },
+                toast: {
+                    loadCharacter: "Failed to load character information.",
+                    loadUnion: "Failed to load union information.",
+                    loadEquip: "Failed to load equipment information.",
+                    loadSkill: "Failed to load skill information.",
+                    loadCash: "Failed to load cash information.",
+                    loadEtc: "Failed to load additional information.",
+                },
+            },
+            banner: {
+                union: "Union Lv. {level}",
+                dojang: "Mu Lung {floor}F",
+                popularity: "Fame {value}",
+                guild: "Guild {name}",
+                figure: "Figure",
+                figureTooltip: "This feature is still under development.",
+            },
+        },
+    },
+    ko: {
+        common: {
+            appName: "MapleStory Finder",
+            languageToggle: {
+                ariaLabel: "언어 전환",
+                short: {
+                    en: "EN",
+                    ko: "KO",
+                },
+                english: "영어",
+                korean: "한국어",
+            },
+            darkModeToggle: {
+                ariaLabel: "다크 모드 전환",
+            },
+            loading: "로딩 중...",
+            level: "Lv. {value}",
+            info: "정보",
+            detail: "상세",
+            search: "검색",
+            or: "또는",
+            home: "홈",
+            backToHome: "메인으로 돌아가기",
+            characterSearch: "캐릭터 검색",
+            findCharacter: "캐릭터를 검색",
+            guest: "게스트",
+        },
+        search: {
+            heading: "검색",
+            description: "원하는 캐릭터를 찾아 상세 정보를 확인할 수 있습니다.",
+            placeholder: "캐릭터 이름을 검색하세요",
+            errors: {
+                empty: "캐릭터 이름을 입력해주세요.",
+                notFound: "캐릭터를 찾을 수 없습니다. 이름을 확인해주세요.",
+            },
+            loading: "검색 중...",
+            button: "검색",
+        },
+        auth: {
+            signIn: {
+                title: "로그인",
+                emailLabel: "이메일",
+                passwordLabel: "비밀번호",
+                submit: "로그인",
+                submitting: "로그인 중...",
+                google: {
+                    start: "구글로 로그인",
+                    loading: "구글로 로그인 중...",
+                },
+                kakao: {
+                    start: "카카오로 로그인",
+                    loading: "카카오로 로그인 중...",
+                },
+                guest: {
+                    start: "게스트로 둘러보기",
+                    loading: "게스트로 입장 중...",
+                },
+                noAccount: "아직 계정이 없으신가요?",
+                signUpCta: "회원가입",
+                toast: {
+                    success: "로그인에 성공했습니다.",
+                    guestSuccess: "게스트로 입장했습니다.",
+                    googleError: "구글 로그인 중 문제가 발생했습니다.",
+                    kakaoError: "카카오 로그인 중 문제가 발생했습니다.",
+                },
+            },
+            signUp: {
+                title: "회원가입",
+                emailLabel: "이메일",
+                passwordLabel: "비밀번호",
+                apiKeyLabel: "넥슨 API 키",
+                submit: "계정 생성",
+                submitting: "계정 생성 중...",
+                alreadyHave: "이미 계정이 있으신가요?",
+                signInCta: "로그인",
+                toast: {
+                    verificationSent: "{email}로 인증 메일이 발송되었습니다. 확인해 주세요.",
+                },
+            },
+        },
+        landing: {
+            hero: {
+                title: "내 캐릭터를 한눈에 정리해 보여주는 『Finder』",
+                description:
+                    "실시간 캐릭터 검색부터 스탯 요약, AI 챗봇, 피규어 생성까지 MapleStory Finder에서 모두 이용해 보세요. 다른 페이지와 어우러지는 깔끔한 레이아웃으로 주요 기능을 빠르게 확인할 수 있습니다.",
+                ctaPrimary: "지금 시작하기",
+                ctaSecondary: "캐릭터 검색",
+            },
+            preview: {
+                title: "Finder 미리보기",
+                description: "Finder에서 내 캐릭터를 검색해보세요.",
+                cards: {
+                    character: {
+                        label: "캐릭터",
+                        title: "실시간 검색",
+                        description: "닉네임과 월드만 입력하면 기본 정보와 스탯을 즉시 확인할 수 있습니다.",
+                    },
+                    insight: {
+                        label: "인사이트",
+                        title: "AI 도우미",
+                        description: "AI가 전투력, 장비 구성 등 궁금한 내용을 대화로 안내합니다.",
+                    },
+                },
+            },
+            highlights: {
+                search: {
+                    title: "실시간 캐릭터 검색",
+                    description: "닉네임과 월드만 입력하면 원하는 캐릭터를 빠르게 찾아 주요 정보를 확인할 수 있습니다.",
+                },
+                stats: {
+                    title: "한눈에 보는 스탯 리포트",
+                    description: "공격력, 보스 대미지, 크리티컬 등 핵심 스탯을 자동으로 정리해 제공합니다.",
+                },
+                equipment: {
+                    title: "장비와 아이템 체크",
+                    description: "현재 착용 중인 장비와 주요 옵션을 깔끔한 카드 형식으로 살펴볼 수 있습니다.",
+                },
+            },
+            quickLinks: {
+                chat: {
+                    title: "Gemini AI 챗봇",
+                    description:
+                        "메이플스토리 데이터를 기반으로 질문에 답하는 대화형 인터페이스를 사용해 보세요.",
+                    cta: "챗봇 열기",
+                },
+                figure: {
+                    title: "캐릭터 피규어 생성",
+                    description:
+                        "AI가 캐릭터 이미지를 바탕으로 3D 피규어 렌더를 생성해 드립니다. 캐릭터 상세에서 바로 이동하세요.",
+                    cta: "피규어 페이지로",
+                },
+            },
+        },
+        notFound: {
+            title: "찾으시던 페이지를 발견하지 못했어요",
+            description:
+                "입력하신 주소가 잘못되었거나 페이지가 이동되었을 수 있어요. 아래의 추천 경로로 이동하거나 검색을 이용해 원하시는 정보를 다시 찾아보세요.",
+            suggestions: {
+                landing: {
+                    title: "랜딩으로 이동",
+                    description: "Finder 소개 페이지에서 제공하는 주요 기능과 소식을 확인해 보세요.",
+                    cta: "메인 살펴보기",
+                },
+                search: {
+                    title: "캐릭터 검색",
+                    description: "월드와 닉네임만 입력하면 실시간으로 캐릭터 정보를 확인할 수 있어요.",
+                    cta: "바로 검색하기",
+                },
+                favorites: {
+                    title: "즐겨찾기 관리",
+                    description: "로그인 후 자주 보는 캐릭터를 저장하고 한곳에서 관리해 보세요.",
+                    cta: "즐겨찾기 이동",
+                },
+            },
+            actions: {
+                home: "메인으로 돌아가기",
+                search: "캐릭터 검색하기",
+            },
+        },
+        home: {
+            characterInfo: {
+                emptyState: "캐릭터를 선택해주세요",
+                detailButton: "상세 보기",
+            },
+            dialog: {
+                title: "정보",
+            },
+        },
+        authProvider: {
+            toast: {
+                logout: "로그아웃되었습니다.",
+                loginRequired: "로그인이 필요한 서비스입니다.",
+            },
+        },
+        character: {
+            detail: {
+                tabs: {
+                    basic: "기본 정보",
+                    union: "유니온",
+                    equip: "장비",
+                    skill: "스킬",
+                    cash: "캐시",
+                    etc: "기타",
+                },
+                toast: {
+                    loadCharacter: "캐릭터 정보 로딩 실패",
+                    loadUnion: "유니온 정보 로딩 실패",
+                    loadEquip: "장비 정보 로딩 실패",
+                    loadSkill: "스킬 정보 로딩 실패",
+                    loadCash: "캐시 정보 로딩 실패",
+                    loadEtc: "기타 정보 로딩 실패",
+                },
+            },
+            banner: {
+                union: "유니온 {level}",
+                dojang: "무릉 {floor}층",
+                popularity: "인기도 {value}",
+                guild: "길드 {name}",
+                figure: "피규어",
+                figureTooltip: "아직 미완성 기능입니다",
+            },
+        },
+    },
+} as const;
+
+export type Language = keyof typeof translations;
+
+export type NestedKeyOf<ObjectType extends Record<string, unknown>> = {
+    [Key in keyof ObjectType & (string | number)]: ObjectType[Key] extends Record<string, unknown>
+        ? `${Key}` | `${Key}.${NestedKeyOf<ObjectType[Key]>}`
+        : `${Key}`;
+}[keyof ObjectType & (string | number)];
+
+export type TranslationKey = NestedKeyOf<(typeof translations)[Language]>;
+
+export const translate = (
+    language: Language,
+    key: TranslationKey,
+    params?: Record<string, string | number>,
+): string => {
+    const parts = key.split(".");
+    let value: unknown = translations[language];
+
+    for (const part of parts) {
+        if (value && typeof value === "object" && part in (value as Record<string, unknown>)) {
+            value = (value as Record<string, unknown>)[part];
+        } else {
+            value = undefined;
+            break;
+        }
+    }
+
+    if (typeof value !== "string") {
+        // fallback to english if missing
+        if (language !== "en") {
+            return translate("en", key, params);
+        }
+        return key;
+    }
+
+    if (!params) {
+        return value;
+    }
+
+    return value.replace(/\{(\w+)\}/g, (_, param) => String(params[param] ?? ""));
+};

--- a/src/constants/i18n/translations.ts
+++ b/src/constants/i18n/translations.ts
@@ -253,12 +253,12 @@ export const translations = {
                 submit: "로그인",
                 submitting: "로그인 중...",
                 google: {
-                    start: "구글로 로그인",
-                    loading: "구글로 로그인 중...",
+                    start: "구글 로그인",
+                    loading: "구글 로그인 중...",
                 },
                 kakao: {
-                    start: "카카오로 로그인",
-                    loading: "카카오로 로그인 중...",
+                    start: "카카오 로그인",
+                    loading: "카카오 로그인 중...",
                 },
                 guest: {
                     start: "게스트로 둘러보기",

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -6,6 +6,7 @@ import type { Session } from "@supabase/supabase-js";
 import { toast } from "sonner";
 import { userStore } from "@/stores/userStore";
 import { supabase } from "@/libs/supabaseClient";
+import { useTranslations } from "@/providers/LanguageProvider";
 
 const GUEST_STORAGE_KEY = "finder_guest";
 
@@ -67,6 +68,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const redirectToastPathRef = useRef<string | null>(null);
     const skipGuestGuardToastRef = useRef(false);
     const skipUnauthenticatedToastRef = useRef(false);
+    const t = useTranslations();
 
     const syncSession = useCallback(async () => {
         setIsLoading(true);
@@ -103,7 +105,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         }
         skipUnauthenticatedToastRef.current = true;
         applyAuthState(null, false, setStatus, setIsLoading);
-        toast.success("로그아웃되었습니다.");
+        toast.success(t("authProvider.toast.logout"));
     }, [applyAuthState, status]);
 
     useEffect(() => {
@@ -112,7 +114,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         if (status === "guest" && pathname && !isGuestAccessiblePath(pathname)) {
             if (redirectToastPathRef.current !== pathname) {
                 if (!skipGuestGuardToastRef.current) {
-                    toast.info("로그인이 필요한 서비스입니다");
+                    toast.info(t("authProvider.toast.loginRequired"));
                 }
                 redirectToastPathRef.current = pathname;
             }
@@ -128,7 +130,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
                 return;
             }
             if (!skipUnauthenticatedToastRef.current) {
-                toast.info("로그인이 필요한 서비스입니다");
+                toast.info(t("authProvider.toast.loginRequired"));
             }
             router.replace("/sign_in");
             return;

--- a/src/providers/LanguageProvider.tsx
+++ b/src/providers/LanguageProvider.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { translate, type Language, type TranslationKey } from "@/constants/i18n/translations";
+
+const LANGUAGE_STORAGE_KEY = "finder_language";
+
+type LanguageContextValue = {
+    language: Language;
+    setLanguage: (language: Language) => void;
+    toggleLanguage: () => void;
+    t: (key: TranslationKey, params?: Record<string, string | number>) => string;
+};
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+const detectBrowserLanguage = (): Language => {
+    if (typeof navigator === "undefined") return "en";
+    return navigator.language?.toLowerCase().startsWith("ko") ? "ko" : "en";
+};
+
+export const LanguageProvider = ({ children }: { children: React.ReactNode }) => {
+    const [language, setLanguageState] = useState<Language>("en");
+    const [initialized, setInitialized] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+        if (stored === "ko" || stored === "en") {
+            setLanguageState(stored);
+        } else {
+            const detected = detectBrowserLanguage();
+            setLanguageState(detected);
+            window.localStorage.setItem(LANGUAGE_STORAGE_KEY, detected);
+        }
+        setInitialized(true);
+    }, []);
+
+    useEffect(() => {
+        if (!initialized) return;
+        if (typeof document !== "undefined") {
+            document.documentElement.lang = language;
+        }
+        if (typeof window !== "undefined") {
+            window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+        }
+    }, [initialized, language]);
+
+    const setLanguage = useCallback((next: Language) => {
+        setLanguageState(next);
+    }, []);
+
+    const toggleLanguage = useCallback(() => {
+        setLanguageState((prev) => (prev === "en" ? "ko" : "en"));
+    }, []);
+
+    const value = useMemo<LanguageContextValue>(() => ({
+        language,
+        setLanguage,
+        toggleLanguage,
+        t: (key, params) => translate(language, key, params),
+    }), [language, setLanguage, toggleLanguage]);
+
+    return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+};
+
+export const useLanguage = () => {
+    const context = useContext(LanguageContext);
+    if (!context) {
+        throw new Error("useLanguage must be used within LanguageProvider");
+    }
+    return context;
+};
+
+export const useTranslations = () => useLanguage().t;


### PR DESCRIPTION
## Summary
* added a shared translation catalogue and language provider that persists the selected locale and exposes a toggle control【F:src/constants/i18n/translations.ts†L1-L410】【F:src/providers/LanguageProvider.tsx†L1-L75】【F:src/components/LanguageToggle.tsx†L1-L31】
* localized primary pages, header actions, and authentication screens while surfacing the language toggle beside existing theme controls【F:src/app/page.tsx†L1-L200】【F:src/app/(main)/search/page.tsx†L1-L94】【F:src/app/not-found.tsx†L1-L120】【F:src/components/Header.tsx†L1-L29】【F:src/app/(auth)/sign_in/page.tsx†L1-L200】【F:src/app/(auth)/sign_up/page.tsx†L1-L108】
* updated character views to deliver translated tab labels, banners, and toast messaging for consistency across detail surfaces【F:src/components/character/CharacterDetail.tsx†L1-L240】【F:src/components/character/CharacterBanner.tsx†L1-L186】

## Testing
* ✅ `npm run lint`【c791c3†L1-L2】

------
https://chatgpt.com/codex/tasks/task_e_68ca9e437fe48324b04b6b64432926d4