### PR TITLE
Replace maintenance alert with dialog

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Script from "next/script";
 import { type ReactNode, unstable_ViewTransition as ViewTransition } from "react";
 import type { Metadata } from "next";
 import "./globals.css";
+import { MaintenanceDialog } from "@/components/common/MaintenanceDialog";
 import { Toaster } from "@/components/ui/sonner";
 import { AuthProvider } from "@/providers/AuthProvider";
 import { LanguageProvider } from "@/providers/LanguageProvider";
@@ -58,6 +59,7 @@ const RootLayout = ({ children }: Readonly<{ children: ReactNode }>) => {
         <LanguageProvider>
             <AuthProvider>
                 <ViewTransition enter="fade" exit="fade">{children}</ViewTransition>
+                <MaintenanceDialog />
                 <Toaster />
             </AuthProvider>
         </LanguageProvider>

--- a/src/components/common/MaintenanceDialog.tsx
+++ b/src/components/common/MaintenanceDialog.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useCallback } from "react";
+import { maintenanceStore } from "@/stores/maintenanceStore";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+
+export const MaintenanceDialog = () => {
+    const { isOpen, message, close } = maintenanceStore();
+
+    const handleOpenChange = useCallback(
+        (open: boolean) => {
+            if (!open) {
+                close();
+            }
+        },
+        [close],
+    );
+
+    if (!message && !isOpen) {
+        return null;
+    }
+
+    return (
+        <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>점검 안내</DialogTitle>
+                    <DialogDescription>{message}</DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                    <Button onClick={close}>확인</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/src/fetchs/apiClient.ts
+++ b/src/fetchs/apiClient.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from "axios";
 import pLimit from "p-limit";
+import { maintenanceStore } from "@/stores/maintenanceStore";
 import { userStore } from "@/stores/userStore";
 
 export type ApiParams = Record<string, string | number | undefined>;
@@ -37,7 +38,7 @@ const showMaintenanceAlert = () => {
     }
 
     hasShownMaintenanceAlert = true;
-    window.alert(MAINTENANCE_ALERT_MESSAGE);
+    maintenanceStore.getState().open(MAINTENANCE_ALERT_MESSAGE);
 };
 
 export const getApiKeyInfo = () => {

--- a/src/stores/maintenanceStore.ts
+++ b/src/stores/maintenanceStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type MaintenanceState = {
+    isOpen: boolean;
+    message: string;
+    open: (message: string) => void;
+    close: () => void;
+};
+
+export const maintenanceStore = create<MaintenanceState>((set) => ({
+    isOpen: false,
+    message: "",
+    open: (message) => set({ isOpen: true, message }),
+    close: () => set({ isOpen: false, message: "" }),
+}));


### PR DESCRIPTION
## Summary
- add a zustand store and dialog component to surface maintenance alerts without blocking the UI
- open the maintenance dialog when maintenance errors are returned from API requests
- include the maintenance dialog in the app layout so it is available across pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb56dc2d848324960a9d0490c1ef6a