### PR TITLE
feat: add progressive web app support

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,31 @@
+{
+  "name": "MapleStory Finder",
+  "short_name": "Finder",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "description": "MapleStory Finder",
+  "background_color": "#0f172a",
+  "theme_color": "#38bdf8",
+  "lang": "ko-KR",
+  "icons": [
+    {
+      "src": "/Reheln.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/Reheln_Dots.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/Reheln.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,73 @@
+const CACHE_NAME = "maplestory-finder-v1";
+const APP_SHELL = ["/", "/offline", "/manifest.webmanifest"];
+
+self.addEventListener("install", (event) => {
+    event.waitUntil(
+        (async () => {
+            const cache = await caches.open(CACHE_NAME);
+            await cache.addAll(APP_SHELL);
+            await self.skipWaiting();
+        })().catch((error) => {
+            console.error("SW install failed:", error);
+        }),
+    );
+});
+
+self.addEventListener("activate", (event) => {
+    event.waitUntil(
+        (async () => {
+            const keys = await caches.keys();
+            await Promise.all(
+                keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)),
+            );
+            await self.clients.claim();
+        })(),
+    );
+});
+
+self.addEventListener("fetch", (event) => {
+    if (event.request.method !== "GET") {
+        return;
+    }
+
+    event.respondWith(
+        (async () => {
+            const cache = await caches.open(CACHE_NAME);
+
+            try {
+                const networkResponse = await fetch(event.request);
+
+                if (
+                    networkResponse &&
+                    networkResponse.status === 200 &&
+                    networkResponse.type === "basic" &&
+                    event.request.url.startsWith(self.location.origin)
+                ) {
+                    cache.put(event.request, networkResponse.clone()).catch(() => {});
+                }
+
+                return networkResponse;
+            } catch (error) {
+                const cachedResponse = await cache.match(event.request);
+                if (cachedResponse) {
+                    return cachedResponse;
+                }
+
+                if (event.request.mode === "navigate") {
+                    const offlineResponse = await cache.match("/offline");
+                    if (offlineResponse) {
+                        return offlineResponse;
+                    }
+                }
+
+                throw error;
+            }
+        })(),
+    );
+});
+
+self.addEventListener("message", (event) => {
+    if (event.data && event.data.type === "SKIP_WAITING") {
+        self.skipWaiting();
+    }
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,10 +27,28 @@ const mapleStory = localFont({
 export const metadata: Metadata = {
     title: "Finder",
     description: "MapleStory Finder",
+    applicationName: "MapleStory Finder",
+    manifest: "/manifest.webmanifest",
+    themeColor: "#38bdf8",
     icons: {
-        icon: "/Reheln.ico",
+        icon: [
+            {
+                url: "/Reheln.ico",
+            },
+            {
+                url: "/Reheln.png",
+                type: "image/png",
+                sizes: "512x512",
+            },
+        ],
+        apple: {
+            url: "/Reheln.png",
+            sizes: "180x180",
+        },
     },
 };
+
+const isProduction = process.env.NODE_ENV === "production";
 
 const RootLayout = ({ children }: Readonly<{ children: ReactNode }>) => {
     return (
@@ -55,6 +73,20 @@ const RootLayout = ({ children }: Readonly<{ children: ReactNode }>) => {
             src={`https://openapi.nexon.com/js/analytics.js?app_id=${process.env.NEXT_PUBLIC_NEXON_APP_ID}`}
             strategy="afterInteractive"
         />
+
+        {isProduction ? (
+            <Script id="pwa-service-worker" strategy="afterInteractive">
+                {`
+                    if ('serviceWorker' in navigator) {
+                      window.addEventListener('load', () => {
+                        navigator.serviceWorker.register('/service-worker.js').catch((error) => {
+                          console.error('Service worker registration failed:', error);
+                        });
+                      });
+                    }
+                `}
+            </Script>
+        ) : null}
 
         <LanguageProvider>
             <AuthProvider>

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+    title: "오프라인 | Finder",
+    description: "인터넷 연결이 없어도 최근에 방문한 페이지를 사용할 수 있습니다.",
+};
+
+const OfflinePage = () => {
+    return (
+        <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-6 text-center">
+            <div className="space-y-3">
+                <h1 className="text-3xl font-bold sm:text-4xl">오프라인 상태입니다</h1>
+                <p className="text-muted-foreground">
+                    인터넷 연결을 확인한 후 다시 시도해주세요. 최근에 방문한 페이지는 일부 오프라인에서도 사용할 수 있습니다.
+                </p>
+            </div>
+            <Link
+                href="/"
+                className="rounded-md bg-sky-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-sky-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70"
+            >
+                홈으로 돌아가기
+            </Link>
+        </main>
+    );
+};
+
+export default OfflinePage;


### PR DESCRIPTION
## Summary
- add a web app manifest and service worker to enable installable offline support
- register the service worker from the root layout and surface an offline fallback route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb61dc65988324be8f54b690d410f1