### PR TITLE
Refine dashboard overview with GSAP-driven UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "eslint-plugin-import": "^2.32.0",
+        "gsap": "^3.13.0",
         "lucide-react": "^0.544.0",
         "next": "15.5.3",
         "p-limit": "^4.0.0",
@@ -4846,6 +4847,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/gtoken": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "eslint-plugin-import": "^2.32.0",
+    "gsap": "^3.13.0",
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
     "p-limit": "^4.0.0",

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { useRouter } from "next/navigation";
-import { unstable_ViewTransition as ViewTransition, useEffect, useState } from "react";
+import { unstable_ViewTransition as ViewTransition, useEffect, useMemo, useRef, useState } from "react";
+import { gsap } from "gsap";
 import { favoriteStore } from "@/stores/favoriteStore";
 import { supabase } from "@/libs/supabaseClient";
 import CharacterInfo from "@/components/home/CharacterInfo";
 import FavoriteList from "@/components/home/FavoriteList";
+import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { findCharacterBasic } from "@/fetchs/character.fetch";
 import { addFavorite, getFavorites, removeFavorite } from "@/fetchs/favorite.fetch";
@@ -21,6 +23,11 @@ const Home = () => {
     const [selected, setSelected] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
     const [open, setOpen] = useState(false);
+    const layoutRef = useRef<HTMLDivElement | null>(null);
+    const accentRefs = useRef<(HTMLDivElement | null)[]>([]);
+    const headerRef = useRef<HTMLDivElement | null>(null);
+    const overviewRef = useRef<HTMLDivElement | null>(null);
+    const focusRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
         const load = async () => {
@@ -52,7 +59,7 @@ const Home = () => {
         };
 
         load();
-    }, []);
+    }, [setFavoriteOcids]);
 
     const toggleFavorite = async (ocid: string) => {
         if (!user) return;
@@ -91,7 +98,6 @@ const Home = () => {
 
     const handleSelect = (ocid: string) => {
         setSelected(ocid);
-        // 모바일일 경우 다이얼로그 열기
         if (window.innerWidth < 768) {
             setOpen(true);
         }
@@ -102,40 +108,425 @@ const Home = () => {
         router.push(`/character/${selected}`);
     };
 
+    const selectedCharacter = useMemo(
+        () => favorites.find((favorite) => favorite.ocid === selected) ?? null,
+        [favorites, selected],
+    );
+
+    const formattedFavorites = useMemo(
+        () => new Intl.NumberFormat().format(favorites.length),
+        [favorites.length],
+    );
+
+    const averageLevel = useMemo(() => {
+        if (!favorites.length) return null;
+        const total = favorites.reduce((sum, character) => sum + character.character_level, 0);
+        return Math.round(total / favorites.length);
+    }, [favorites]);
+
+    const averageLabel = averageLevel ? t('common.level', { value: averageLevel }) : '—';
+    const focusValue = selectedCharacter
+        ? selectedCharacter.character_name
+        : t('home.dashboard.stats.focusEmpty');
+    const focusHelper = selectedCharacter
+        ? `${selectedCharacter.character_class} · ${selectedCharacter.world_name}`
+        : t('home.dashboard.stats.focusHelper');
+    const focusBadges = useMemo(
+        () =>
+            selectedCharacter
+                ? [
+                      selectedCharacter.character_class,
+                      t('common.level', { value: selectedCharacter.character_level }),
+                  ]
+                : [],
+        [selectedCharacter, t],
+    );
+    const focusBadgeKey = useMemo(() => focusBadges.join('|'), [focusBadges]);
+    const topFavorites = useMemo(() => favorites.slice(0, 4), [favorites]);
+    const topFavoritesKey = useMemo(
+        () => topFavorites.map((favorite) => favorite.ocid).join('|'),
+        [topFavorites],
+    );
+    const focusCharacterKey = selectedCharacter?.ocid ?? 'none';
+
+    useEffect(() => {
+        const ctx = gsap.context(() => {
+            const elements = accentRefs.current.filter(
+                (element): element is HTMLDivElement => Boolean(element),
+            );
+            elements.forEach((element, index) => {
+                gsap.to(element, {
+                    xPercent: gsap.utils.random(-10, 10),
+                    yPercent: gsap.utils.random(-8, 8),
+                    scale: gsap.utils.random(0.92, 1.08),
+                    rotate: gsap.utils.random(-6, 6),
+                    duration: gsap.utils.random(7, 12),
+                    ease: "sine.inOut",
+                    yoyo: true,
+                    repeat: -1,
+                    delay: index * 0.55,
+                });
+            });
+        }, layoutRef);
+
+        return () => ctx.revert();
+    }, []);
+
+    useEffect(() => {
+        if (!headerRef.current) return;
+        const ctx = gsap.context(() => {
+            const items = Array.from(headerRef.current?.children ?? []) as HTMLElement[];
+            if (!items.length) return;
+            gsap.fromTo(
+                items,
+                { y: 26, opacity: 0 },
+                { y: 0, opacity: 1, duration: 0.6, ease: "power3.out", stagger: 0.08 },
+            );
+        }, headerRef);
+
+        return () => ctx.revert();
+    }, []);
+
+    useEffect(() => {
+        if (loading) return;
+        if (!overviewRef.current) return;
+        const ctx = gsap.context(() => {
+            const timeline = gsap.timeline({ defaults: { ease: "power3.out" } });
+            timeline.fromTo(
+                overviewRef.current,
+                { y: 32, opacity: 0 },
+                { y: 0, opacity: 1, duration: 0.65 },
+            );
+            const sections = overviewRef.current
+                ?.querySelectorAll<HTMLElement>('[data-animate="overview"]') ?? [];
+            if (sections.length) {
+                timeline.fromTo(
+                    sections,
+                    { y: 24, opacity: 0 },
+                    { y: 0, opacity: 1, duration: 0.55, stagger: 0.12 },
+                    "-=0.35",
+                );
+            }
+        }, overviewRef);
+
+        return () => ctx.revert();
+    }, [averageLabel, formattedFavorites, loading, topFavoritesKey]);
+
+    useEffect(() => {
+        if (loading) return;
+        if (!focusRef.current) return;
+        const ctx = gsap.context(() => {
+            const timeline = gsap.timeline({ defaults: { ease: "power3.out" } });
+            timeline.fromTo(
+                focusRef.current,
+                { y: 32, opacity: 0 },
+                { y: 0, opacity: 1, duration: 0.65 },
+            );
+            const sections = focusRef.current
+                ?.querySelectorAll<HTMLElement>('[data-animate="focus"]') ?? [];
+            if (sections.length) {
+                timeline.fromTo(
+                    sections,
+                    { y: 20, opacity: 0 },
+                    { y: 0, opacity: 1, duration: 0.5, stagger: 0.1 },
+                    "-=0.35",
+                );
+            }
+        }, focusRef);
+
+        return () => ctx.revert();
+    }, [focusBadgeKey, focusCharacterKey, focusHelper, focusValue, loading, topFavoritesKey]);
+
     return (
         <ViewTransition enter="fade" exit="fade">
-            <div className="flex h-full">
-                {/* 캐릭터 목록 */}
-                <FavoriteList
-                    favorites={favorites}
-                    loading={loading}
-                    onSelect={handleSelect}
-                    onToggleFavorite={toggleFavorite}
-                />
+            <div
+                ref={layoutRef}
+                className="relative flex h-full w-full overflow-hidden rounded-[2.75rem] border border-border"
+                style={{
+                    background:
+                        "linear-gradient(150deg, color-mix(in srgb, var(--background) 95%, transparent) 0%, color-mix(in srgb, var(--background) 88%, transparent) 55%, color-mix(in srgb, var(--primary) 12%, transparent) 100%)",
+                    boxShadow: "0 40px 120px rgba(15, 23, 42, 0.38)",
+                }}
+            >
+                <div className="pointer-events-none absolute inset-0">
+                    <div
+                        ref={(element) => {
+                            accentRefs.current[0] = element;
+                        }}
+                        className="absolute -left-32 top-10 h-72 w-72 rounded-full blur-[120px]"
+                        style={{
+                            background:
+                                "radial-gradient(circle, color-mix(in srgb, var(--primary) 30%, transparent) 0%, transparent 70%)",
+                            opacity: 0.35,
+                        }}
+                    />
+                    <div
+                        ref={(element) => {
+                            accentRefs.current[1] = element;
+                        }}
+                        className="absolute right-[-110px] top-[-80px] h-96 w-96 rounded-full blur-[140px]"
+                        style={{
+                            background:
+                                "radial-gradient(circle, color-mix(in srgb, var(--primary) 22%, transparent) 0%, transparent 70%)",
+                            opacity: 0.28,
+                        }}
+                    />
+                    <div
+                        ref={(element) => {
+                            accentRefs.current[2] = element;
+                        }}
+                        className="absolute bottom-[-150px] left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full blur-[160px]"
+                        style={{
+                            background:
+                                "radial-gradient(circle, color-mix(in srgb, var(--primary) 18%, transparent) 0%, transparent 70%)",
+                            opacity: 0.3,
+                        }}
+                    />
+                </div>
 
-                {/* 캐릭터 정보 */}
-                <CharacterInfo ocid={selected} goToDetailPage={goToDetailPage} />
+                <div className="relative z-10 flex h-full w-full flex-col gap-8 p-6 lg:p-12">
+                    <header ref={headerRef} className="space-y-3">
+                        <span className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">
+                            {t('home.dashboard.label')}
+                        </span>
+                        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl lg:text-5xl">
+                            {t('home.dashboard.title')}
+                        </h1>
+                        <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+                            {t('home.dashboard.subtitle')}
+                        </p>
+                    </header>
 
-                {/* 모바일 다이얼로그 */}
-                <Dialog open={open} onOpenChange={setOpen}>
-                    <DialogContent
-                        className="
-                            fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                            w-[90vw] max-w-md max-h-[90vh] overflow-y-auto
-                            rounded-2xl bg-background p-0 shadow-lg
-                        "
-                    >
-                        <DialogTitle className="px-4 pt-4">{t('home.dialog.title')}</DialogTitle>
-                        <CharacterInfo
-                            ocid={selected}
-                            goToDetailPage={goToDetailPage}
-                            className="flex md:hidden max-h-[80vh]"
+                    <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+                        <section
+                            ref={overviewRef}
+                            className="relative overflow-hidden rounded-[2rem] border border-border/70 bg-card/70 shadow-[0_26px_80px_rgba(15,23,42,0.22)] backdrop-blur-xl"
+                            style={{
+                                background:
+                                    "linear-gradient(155deg, color-mix(in srgb, var(--card) 92%, transparent) 0%, color-mix(in srgb, var(--background) 95%, transparent) 55%, color-mix(in srgb, var(--primary) 16%, transparent) 100%)",
+                            }}
+                        >
+                            <div className="pointer-events-none absolute inset-0">
+                                <div
+                                    ref={(element) => {
+                                        accentRefs.current[3] = element;
+                                    }}
+                                    className="absolute -right-24 -top-16 h-64 w-64 rounded-full blur-3xl"
+                                    style={{
+                                        background:
+                                            "radial-gradient(circle, color-mix(in srgb, var(--primary) 26%, transparent) 0%, transparent 70%)",
+                                        opacity: 0.25,
+                                    }}
+                                />
+                            </div>
+
+                            <div className="relative z-10 flex h-full flex-col gap-6 p-6 sm:p-8">
+                                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                                    <div className="space-y-3" data-animate="overview">
+                                        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                                            {t('home.dashboard.stats.saved')}
+                                        </span>
+                                        <p className="text-4xl font-semibold text-foreground sm:text-5xl">
+                                            {formattedFavorites}
+                                        </p>
+                                        <p className="max-w-xl text-sm text-muted-foreground">
+                                            {t('home.dashboard.stats.savedHelper')}
+                                        </p>
+                                    </div>
+                                    <div
+                                        data-animate="overview"
+                                        className="rounded-[1.75rem] border border-border/70 bg-background/50 px-6 py-5 shadow-lg backdrop-blur-xl sm:max-w-[280px]"
+                                        style={{
+                                            background:
+                                                "linear-gradient(160deg, color-mix(in srgb, var(--background) 92%, transparent) 0%, color-mix(in srgb, var(--background) 84%, transparent) 55%, color-mix(in srgb, var(--primary) 18%, transparent) 100%)",
+                                        }}
+                                    >
+                                        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                                            {t('home.dashboard.stats.average')}
+                                        </span>
+                                        <p className="mt-3 text-3xl font-semibold text-foreground sm:text-4xl">{averageLabel}</p>
+                                        <p className="mt-3 text-xs text-muted-foreground">
+                                            {t('home.dashboard.stats.averageHelper')}
+                                        </p>
+                                    </div>
+                                </div>
+
+                                <div
+                                    data-animate="overview"
+                                    className="rounded-[1.75rem] border border-border/70 bg-background/55 p-6 shadow-lg backdrop-blur-xl"
+                                    style={{
+                                        background:
+                                            "linear-gradient(160deg, color-mix(in srgb, var(--background) 94%, transparent) 0%, color-mix(in srgb, var(--background) 88%, transparent) 100%)",
+                                    }}
+                                >
+                                    <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                                        {t('home.dashboard.list.title')}
+                                    </span>
+                                    <p className="mt-2 text-sm text-muted-foreground">
+                                        {t('home.dashboard.list.description')}
+                                    </p>
+                                    <div className="mt-4 flex flex-wrap gap-2">
+                                        {topFavorites.map((character) => (
+                                            <span
+                                                key={character.ocid}
+                                                className="rounded-full border border-border/80 bg-background/60 px-4 py-1 text-xs font-medium uppercase tracking-[0.2em] text-foreground shadow-sm backdrop-blur"
+                                            >
+                                                {character.character_name}
+                                            </span>
+                                        ))}
+                                        {favorites.length > topFavorites.length ? (
+                                            <span className="rounded-full border border-border/70 bg-background/40 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground backdrop-blur">
+                                                +{favorites.length - topFavorites.length}
+                                            </span>
+                                        ) : null}
+                                        {!topFavorites.length ? (
+                                            <span className="rounded-full border border-dashed border-border/80 bg-background/45 px-4 py-1 text-xs text-muted-foreground backdrop-blur">
+                                                {t('home.dashboard.list.empty')}
+                                            </span>
+                                        ) : null}
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+
+                        <section
+                            ref={focusRef}
+                            className="relative overflow-hidden rounded-[2rem] border border-border/60 bg-card/80 shadow-[0_24px_72px_rgba(15,23,42,0.22)] backdrop-blur-xl"
+                            style={{
+                                background:
+                                    "linear-gradient(160deg, color-mix(in srgb, var(--card) 88%, transparent) 0%, color-mix(in srgb, var(--primary) 20%, transparent) 100%)",
+                            }}
+                        >
+                            <div className="pointer-events-none absolute inset-0">
+                                <div
+                                    ref={(element) => {
+                                        accentRefs.current[4] = element;
+                                    }}
+                                    className="absolute left-1/2 top-[-70px] h-72 w-72 -translate-x-1/2 rounded-full blur-[140px]"
+                                    style={{
+                                        background:
+                                            "radial-gradient(circle, color-mix(in srgb, var(--primary) 28%, transparent) 0%, transparent 70%)",
+                                        opacity: 0.35,
+                                    }}
+                                />
+                            </div>
+
+                            <div className="relative z-10 flex h-full flex-col gap-6 p-6 sm:p-8">
+                                <div className="space-y-3" data-animate="focus">
+                                    <span className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground">
+                                        {t('home.dashboard.stats.focus')}
+                                    </span>
+                                    <p className="text-3xl font-semibold text-foreground sm:text-4xl">{focusValue}</p>
+                                    <p className="text-sm text-muted-foreground">{focusHelper}</p>
+                                </div>
+
+                                {focusBadges.length ? (
+                                    <div className="flex flex-wrap gap-2" data-animate="focus">
+                                        {focusBadges.map((badge) => (
+                                            <span
+                                                key={badge}
+                                                className="rounded-full border border-border/80 bg-background/60 px-4 py-1 text-xs font-medium tracking-wide text-foreground shadow-sm backdrop-blur"
+                                            >
+                                                {badge}
+                                            </span>
+                                        ))}
+                                    </div>
+                                ) : null}
+
+                                <div className="mt-auto space-y-4" data-animate="focus">
+                                    <div className="flex items-center justify-between">
+                                        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                                            {t('home.dashboard.list.title')}
+                                        </span>
+                                        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                                            {t('home.dashboard.list.totalLabel')}
+                                            <span className="ml-2 text-base font-semibold tracking-normal text-foreground">
+                                                {formattedFavorites}
+                                            </span>
+                                        </span>
+                                    </div>
+                                    <div className="flex flex-col gap-3">
+                                        {topFavorites.map((character) => (
+                                            <div
+                                                key={character.ocid}
+                                                className={`flex items-center justify-between gap-3 rounded-2xl border border-border/70 bg-background/55 px-4 py-3 text-sm text-foreground shadow-sm backdrop-blur transition-colors ${
+                                                    selected === character.ocid ? 'border-primary/60 bg-primary/15' : ''
+                                                }`}
+                                            >
+                                                <div className="flex flex-col">
+                                                    <span className="font-medium tracking-tight">
+                                                        {character.character_name}
+                                                    </span>
+                                                    <span
+                                                        className={`text-xs ${
+                                                            selected === character.ocid
+                                                                ? 'text-primary-foreground/80'
+                                                                : 'text-muted-foreground'
+                                                        }`}
+                                                    >
+                                                        {character.character_class} · {character.world_name}
+                                                    </span>
+                                                </div>
+                                                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                                                    {t('common.level', { value: character.character_level })}
+                                                </span>
+                                            </div>
+                                        ))}
+                                        {!topFavorites.length ? (
+                                            <div className="rounded-2xl border border-dashed border-border/70 bg-background/55 px-4 py-6 text-center text-sm text-muted-foreground backdrop-blur">
+                                                {t('home.dashboard.stats.focusHelper')}
+                                            </div>
+                                        ) : null}
+                                        {favorites.length > topFavorites.length ? (
+                                            <div className="rounded-2xl border border-border/70 bg-background/45 px-4 py-2 text-center text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground backdrop-blur">
+                                                +{favorites.length - topFavorites.length}
+                                            </div>
+                                        ) : null}
+                                    </div>
+                                    {selectedCharacter ? (
+                                        <div className="pt-2">
+                                            <Button
+                                                variant="outline"
+                                                className="w-full border-border bg-background/60 text-foreground shadow-md backdrop-blur"
+                                                onClick={goToDetailPage}
+                                            >
+                                                {t('home.characterInfo.detailButton')}
+                                            </Button>
+                                        </div>
+                                    ) : null}
+                                </div>
+                            </div>
+                        </section>
+                    </div>
+
+                    <div className="flex min-h-0 flex-1 flex-col gap-6 lg:flex-row">
+                        <FavoriteList
+                            favorites={favorites}
+                            loading={loading}
+                            onSelect={handleSelect}
+                            onToggleFavorite={toggleFavorite}
+                            selected={selected}
+                            className="w-full lg:w-[360px] xl:w-[420px]"
                         />
-                    </DialogContent>
-
-                </Dialog>
-
+                        <CharacterInfo ocid={selected} goToDetailPage={goToDetailPage} />
+                    </div>
+                </div>
             </div>
+
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent
+                    className="fixed left-1/2 top-1/2 max-h-[90vh] w-[92vw] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-[2rem] border border-border/70 bg-background/95 p-0 shadow-2xl backdrop-blur"
+                >
+                    <DialogTitle className="px-5 pt-5 text-sm font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                        {t('home.dialog.title')}
+                    </DialogTitle>
+                    <CharacterInfo
+                        ocid={selected}
+                        goToDetailPage={goToDetailPage}
+                        className="flex max-h-[80vh] md:hidden"
+                    />
+                </DialogContent>
+            </Dialog>
         </ViewTransition>
     );
 };

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -6,12 +6,14 @@ import WorldIcon from "@/components/common/WorldIcon";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import { cn } from "@/utils/utils";
 
 interface ICharacterCardProps {
     character: ICharacterSummary;
     isFavorite?: boolean;
     onToggleFavorite?: () => void;
     onSelect?: () => void;
+    className?: string;
 }
 
 const CharacterCard = ({
@@ -19,12 +21,24 @@ const CharacterCard = ({
     isFavorite,
     onToggleFavorite,
     onSelect,
+    className,
 }: ICharacterCardProps) => {
     return (
         <Card
-            className={`p-4 flex flex-col relative w-full ${onSelect ? "cursor-pointer" : ""}`}
+            className={cn(
+                "favorite-card group relative w-full overflow-hidden rounded-2xl p-4 transition-all duration-300",
+                onSelect ? "cursor-pointer" : "",
+                className,
+            )}
             onClick={onSelect}
         >
+            <div
+                className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                style={{
+                    background:
+                        "linear-gradient(135deg, color-mix(in srgb, var(--primary) 18%, transparent) 0%, color-mix(in srgb, var(--primary) 6%, transparent) 45%, transparent 90%)",
+                }}
+            />
             {/* 서버 정보 */}
             <div className="absolute top-2 left-2 z-10 flex items-center gap-1">
                 <WorldIcon name={character.world_name} />

--- a/src/components/home/CharacterInfo.tsx
+++ b/src/components/home/CharacterInfo.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import Image from "next/image";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { gsap } from "gsap";
 import { useCharacterPreviewStore } from "@/stores/characterPreviewStore";
 import ItemEquipments from "@/components/character/item/ItemEquipments";
 import WorldIcon from "@/components/common/WorldIcon";
@@ -26,6 +27,10 @@ const CharacterInfo = ({ ocid, goToDetailPage, className }: ICharacterInfoProps)
     const [loading, setLoading] = useState(false);
     const setPreview = useCharacterPreviewStore((state) => state.setPreview);
     const clearPreview = useCharacterPreviewStore((state) => state.clear);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const cardRef = useRef<HTMLDivElement | null>(null);
+    const infoRef = useRef<HTMLDivElement | null>(null);
+    const gearRef = useRef<HTMLDivElement | null>(null);
 
     const imageTransitionName = useMemo(() => {
         if (!ocid) return undefined;
@@ -70,86 +75,185 @@ const CharacterInfo = ({ ocid, goToDetailPage, className }: ICharacterInfoProps)
         return `/api/crop?url=${encodeURIComponent(basic.character_image)}`;
     }, [basic?.character_image]);
 
+    useEffect(() => {
+        if (!basic || loading) return;
+        const context = gsap.context(() => {
+            const timeline = gsap.timeline({ defaults: { ease: "power3.out" } });
+            if (cardRef.current) {
+                timeline.fromTo(
+                    cardRef.current,
+                    { opacity: 0, y: 28 },
+                    { opacity: 1, y: 0, duration: 0.65 },
+                );
+            }
+            if (infoRef.current) {
+                const elements = infoRef.current.querySelectorAll<HTMLElement>('[data-animate="meta"]');
+                if (elements.length) {
+                    timeline.fromTo(
+                        elements,
+                        { y: 18, opacity: 0 },
+                        { y: 0, opacity: 1, duration: 0.45, stagger: 0.08 },
+                        "-=0.35",
+                    );
+                }
+            }
+            if (gearRef.current) {
+                timeline.fromTo(
+                    gearRef.current,
+                    { opacity: 0, y: 32 },
+                    { opacity: 1, y: 0, duration: 0.6 },
+                    "-=0.35",
+                );
+            }
+        }, containerRef);
+        return () => context.revert();
+    }, [basic, loading, ocid]);
+
     return (
-        <ScrollArea className={cn("hidden md:flex flex-1", className)}>
+        <ScrollArea className={cn("hidden min-h-0 flex-1 md:flex", className)}>
             {!ocid ? (
-                <div className="flex justify-center items-center w-full h-page animate-pulse">
-                    {t('home.characterInfo.emptyState')}
+                <div className="flex h-full items-center justify-center px-6 text-center text-muted-foreground">
+                    <div className="rounded-3xl border border-dashed border-border px-10 py-12">
+                        {t('home.characterInfo.emptyState')}
+                    </div>
                 </div>
             ) : (
-                <div className="p-4 max-w-6xl mx-auto">
-                    <div className="flex flex-col lg:flex-row gap-10">
-                        <section className="lg:flex-[0.4] flex flex-col items-center max-w-[300px] mx-auto">
-                            <div className="self-start flex items-center gap-2 text-xl">
+                <div ref={containerRef} className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 md:px-6 lg:px-10">
+                    <div
+                        ref={cardRef}
+                        className="relative flex flex-col overflow-hidden rounded-3xl border border-border shadow-2xl lg:flex-row"
+                        style={{
+                            background:
+                                "linear-gradient(150deg, color-mix(in srgb, var(--card) 94%, transparent) 0%, color-mix(in srgb, var(--background) 88%, transparent) 55%, color-mix(in srgb, var(--primary) 14%, transparent) 100%)",
+                        }}
+                    >
+                        <div className="pointer-events-none absolute inset-0">
+                            <div
+                                className="absolute -left-24 top-12 h-64 w-64 rounded-full blur-3xl"
+                                style={{
+                                    background:
+                                        "radial-gradient(circle, color-mix(in srgb, var(--primary) 36%, transparent) 0%, transparent 70%)",
+                                    opacity: 0.45,
+                                }}
+                            />
+                            <div
+                                className="absolute bottom-[-72px] right-[-48px] h-80 w-80 rounded-full blur-3xl"
+                                style={{
+                                    background:
+                                        "radial-gradient(circle, color-mix(in srgb, var(--primary) 24%, transparent) 0%, transparent 70%)",
+                                    opacity: 0.35,
+                                }}
+                            />
+                        </div>
+
+                        <section
+                            ref={infoRef}
+                            className="relative z-10 flex flex-col items-center gap-6 px-6 pb-10 pt-8 text-center lg:flex-[0.45] lg:items-start lg:px-10 lg:pb-12 lg:pt-12 lg:text-left"
+                        >
+                            <div
+                                data-animate="meta"
+                                className="inline-flex items-center gap-3 rounded-full border border-border px-4 py-2 text-sm font-medium"
+                                style={{
+                                    background:
+                                        "linear-gradient(120deg, color-mix(in srgb, var(--background) 94%, transparent) 0%, color-mix(in srgb, var(--background) 88%, transparent) 100%)",
+                                }}
+                            >
                                 {loading || !basic ? (
                                     <>
-                                        <Skeleton className="w-6 h-6 rounded-full" />
-                                        <Skeleton className="h-6 w-24" />
+                                        <Skeleton className="h-6 w-6 rounded-full" />
+                                        <Skeleton className="h-5 w-24" />
                                     </>
                                 ) : (
                                     <>
                                         <WorldIcon name={basic.world_name} />
-                                        {basic.world_name}
+                                        <span>{basic.world_name}</span>
                                     </>
                                 )}
                             </div>
 
-                            {loading || !basic ? (
-                                <Skeleton className="w-64 h-64 mt-4" />
-                            ) : (
-                                characterImageSrc && (
-                                    <div
-                                        className="w-64 h-64 mt-4 flex items-center justify-center"
-                                        style={imageTransitionName ? { viewTransitionName: imageTransitionName } : undefined}
-                                    >
-                                        <Image
-                                            src={characterImageSrc}
-                                            alt={basic.character_name}
-                                            className="object-contain h-auto"
-                                            width={100}
-                                            height={100}
-                                            priority
-                                        />
-                                    </div>
-                                )
-                            )}
-
-                            {loading || !basic ? (
-                                <Skeleton className="h-8 w-40 mt-4" />
-                            ) : (
-                                <h2 className="text-2xl font-bold mt-4 text-center lg:text-left">
-                                    {basic.character_name}
-                                </h2>
-                            )}
-
-                            {loading || !basic ? (
-                                <Skeleton className="h-6 w-32" />
-                            ) : (
-                                <p className="text-center lg:text-left text-muted-foreground">
-                                    {basic.character_class}
-                                </p>
-                            )}
-
-                            {loading || !basic ? (
-                                <Skeleton className="h-6 w-24" />
-                            ) : (
-                                <p className="text-center lg:text-left font-bold text-red-500">
-                                    Lv. {basic.character_level}
-                                </p>
-                            )}
-
-                            <div className="flex justify-center">
+                            <div
+                                data-animate="meta"
+                                className="relative flex aspect-square w-64 max-w-full items-center justify-center overflow-hidden rounded-3xl border border-border"
+                                style={{
+                                    background:
+                                        "linear-gradient(180deg, color-mix(in srgb, var(--background) 96%, transparent) 0%, color-mix(in srgb, var(--background) 85%, transparent) 100%)",
+                                }}
+                            >
                                 {loading || !basic ? (
-                                    <Skeleton className="h-10 w-20" />
+                                    <Skeleton className="h-56 w-56" />
                                 ) : (
-                                    <Button onClick={goToDetailPage}>{t('home.characterInfo.detailButton')}</Button>
+                                    characterImageSrc && (
+                                        <div
+                                            className="flex h-full w-full items-center justify-center"
+                                            style={
+                                                imageTransitionName
+                                                    ? { viewTransitionName: imageTransitionName }
+                                                    : undefined
+                                            }
+                                        >
+                                            <Image
+                                                src={characterImageSrc}
+                                                alt={basic.character_name}
+                                                className="h-auto w-full max-w-[220px] object-contain"
+                                                width={220}
+                                                height={220}
+                                                priority
+                                            />
+                                        </div>
+                                    )
                                 )}
+                            </div>
+
+                            <div className="flex w-full flex-col items-center gap-3 lg:items-start">
+                                <div className="flex w-full flex-col gap-2" data-animate="meta">
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-8 w-48" />
+                                    ) : (
+                                        <h2 className="text-3xl font-semibold tracking-tight">
+                                            {basic.character_name}
+                                        </h2>
+                                    )}
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-5 w-32" />
+                                    ) : (
+                                        <p className="text-sm text-muted-foreground">{basic.character_class}</p>
+                                    )}
+                                </div>
+
+                                <div className="flex flex-wrap items-center justify-center gap-3 lg:justify-start" data-animate="meta">
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-6 w-24" />
+                                    ) : (
+                                        <span
+                                            className="rounded-full px-4 py-1 text-xs font-semibold tracking-wide"
+                                            style={{
+                                                background:
+                                                    "linear-gradient(120deg, color-mix(in srgb, var(--primary) 26%, transparent) 0%, color-mix(in srgb, var(--primary) 12%, transparent) 100%)",
+                                                color: "var(--primary-foreground)",
+                                            }}
+                                        >
+                                            {t('common.level', { value: basic.character_level })}
+                                        </span>
+                                    )}
+                                </div>
+
+                                <div className="pt-2" data-animate="meta">
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-11 w-28" />
+                                    ) : (
+                                        <Button size="lg" onClick={goToDetailPage} className="shadow-md">
+                                            {t('home.characterInfo.detailButton')}
+                                        </Button>
+                                    )}
+                                </div>
                             </div>
                         </section>
 
-                        {/* 우측: 장비 */}
-                        <div className="lg:flex-[0.6] flex justify-center">
-                            <div className="mx-auto max-w-[360px] md:max-w-[420px]">
+                        <div
+                            ref={gearRef}
+                            className="relative z-10 flex flex-1 items-center justify-center px-6 pb-10 pt-0 lg:px-10 lg:pb-12"
+                        >
+                            <div className="w-full max-w-[420px]">
                                 <ItemEquipments items={items} loading={loading || !basic} />
                             </div>
                         </div>

--- a/src/components/home/FavoriteList.tsx
+++ b/src/components/home/FavoriteList.tsx
@@ -1,34 +1,148 @@
 'use client'
 
+import { useEffect, useMemo, useRef } from "react";
+import { gsap } from "gsap";
 import CharacterCard from "@/components/character/CharacterCard";
 import CharacterCardSkeleton from "@/components/character/CharacterCardSkeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import { useTranslations } from "@/providers/LanguageProvider";
+import { cn } from "@/utils/utils";
 
 interface IFavoriteListProps {
     favorites: ICharacterSummary[];
     loading: boolean;
     onSelect: (ocid: string) => void;
     onToggleFavorite: (ocid: string) => void;
+    selected?: string | null;
+    className?: string;
 }
 
-const FavoriteList = ({ favorites, loading, onSelect, onToggleFavorite }: IFavoriteListProps) => {
+const FavoriteList = ({
+    favorites,
+    loading,
+    onSelect,
+    onToggleFavorite,
+    selected,
+    className,
+}: IFavoriteListProps) => {
+    const panelRef = useRef<HTMLDivElement | null>(null);
+    const t = useTranslations();
+    const hasFavorites = favorites.length > 0;
+
+    useEffect(() => {
+        const context = gsap.context(() => {
+            gsap.fromTo(
+                panelRef.current,
+                { y: 24, opacity: 0 },
+                { y: 0, opacity: 1, duration: 0.65, ease: "power3.out" },
+            );
+        }, panelRef);
+        return () => context.revert();
+    }, []);
+
+    useEffect(() => {
+        if (loading) return;
+        const context = gsap.context(() => {
+            const items = gsap.utils.toArray<HTMLElement>(".favorite-card");
+            if (!items.length) return;
+            gsap.fromTo(
+                items,
+                { y: 18, opacity: 0 },
+                { y: 0, opacity: 1, duration: 0.5, ease: "power3.out", stagger: 0.08 },
+            );
+        }, panelRef);
+        return () => context.revert();
+    }, [favorites, loading]);
+
+    const totalLabel = useMemo(
+        () =>
+            new Intl.NumberFormat(undefined, {
+                notation: "standard",
+            }).format(favorites.length),
+        [favorites.length],
+    );
+
     return (
-        <ScrollArea className="w-full md:w-1/3 md:border-r p-4">
-            <div className="space-y-4">
-                {loading
-                    ? Array.from({ length: 3 }).map((_, i) => <CharacterCardSkeleton key={i} />)
-                    : favorites.map((c) => (
-                        <CharacterCard
-                            key={c.ocid}
-                            character={c}
-                            isFavorite
-                            onToggleFavorite={() => onToggleFavorite(c.ocid)}
-                            onSelect={() => onSelect(c.ocid)}
-                        />
-                    ))}
+        <div
+            ref={panelRef}
+            className={cn(
+                "relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-3xl border border-border bg-card shadow-xl",
+                "backdrop-blur-xl",
+                className,
+            )}
+            style={{
+                background:
+                    "linear-gradient(160deg, color-mix(in srgb, var(--card) 88%, transparent) 0%, color-mix(in srgb, var(--background) 94%, transparent) 60%, color-mix(in srgb, var(--primary) 10%, transparent) 100%)",
+            }}
+        >
+            <div className="pointer-events-none absolute inset-0">
+                <div
+                    className="absolute -left-24 top-20 h-56 w-56 rounded-full blur-3xl"
+                    style={{
+                        background:
+                            "radial-gradient(circle, color-mix(in srgb, var(--primary) 45%, transparent) 0%, transparent 70%)",
+                        opacity: 0.55,
+                    }}
+                />
+                <div
+                    className="absolute -bottom-16 right-0 h-64 w-64 rounded-full blur-3xl"
+                    style={{
+                        background:
+                            "radial-gradient(circle, color-mix(in srgb, var(--primary) 30%, transparent) 0%, transparent 70%)",
+                        opacity: 0.4,
+                    }}
+                />
             </div>
-        </ScrollArea>
+
+            <div className="relative z-10 border-b border-border px-6 pb-5 pt-6">
+                <p className="text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground">
+                    {t('home.dashboard.label')}
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold text-foreground">
+                    {t('home.dashboard.list.title')}
+                </h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                    {t('home.dashboard.list.description')}
+                </p>
+                <div className="mt-4 flex items-center justify-between text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground">
+                    <span>{t('home.dashboard.list.totalLabel')}</span>
+                    <span className="text-lg tracking-normal text-foreground">{totalLabel}</span>
+                </div>
+            </div>
+
+            <ScrollArea className="relative z-10 flex-1 px-6 pb-6 pt-4">
+                <div className="space-y-4">
+                    {loading
+                        ? Array.from({ length: 3 }).map((_, i) => <CharacterCardSkeleton key={i} />)
+                        : hasFavorites ? (
+                              favorites.map((c) => (
+                                  <CharacterCard
+                                      key={c.ocid}
+                                      character={c}
+                                      isFavorite
+                                      className={cn(
+                                          "border border-border bg-background shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl",
+                                          selected === c.ocid && "ring-2 ring-primary shadow-xl",
+                                      )}
+                                      onToggleFavorite={() => onToggleFavorite(c.ocid)}
+                                      onSelect={() => onSelect(c.ocid)}
+                                  />
+                              ))
+                          ) : (
+                              <div
+                                  className="flex min-h-[200px] flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-background p-6 text-center text-sm text-muted-foreground"
+                                  style={{
+                                      background:
+                                          "linear-gradient(180deg, color-mix(in srgb, var(--background) 92%, transparent) 0%, color-mix(in srgb, var(--background) 86%, transparent) 100%)",
+                                  }}
+                              >
+                                  {t('home.dashboard.list.empty')}
+                              </div>
+                          )}
+                </div>
+            </ScrollArea>
+        </div>
     );
 };
 

--- a/src/constants/i18n/translations.ts
+++ b/src/constants/i18n/translations.ts
@@ -170,6 +170,26 @@ export const translations = {
             },
         },
         home: {
+            dashboard: {
+                label: "Dashboard",
+                title: "Favorite dashboard",
+                subtitle: "Curate and explore your MapleStory heroes with live previews.",
+                stats: {
+                    saved: "Saved heroes",
+                    savedHelper: "Characters pinned for quick access",
+                    average: "Average level",
+                    averageHelper: "Level overview across saved characters",
+                    focus: "Current focus",
+                    focusHelper: "Select a character to preview their gear",
+                    focusEmpty: "No character selected",
+                },
+                list: {
+                    title: "Favorite lineup",
+                    description: "Tap a card to preview gear or toggle the star to manage your lineup.",
+                    totalLabel: "Total saved",
+                    empty: "Save characters to build your personal dashboard.",
+                },
+            },
             characterInfo: {
                 emptyState: "Please choose your character",
                 detailButton: "Detail",
@@ -378,6 +398,26 @@ export const translations = {
             },
         },
         home: {
+            dashboard: {
+                label: "대시보드",
+                title: "즐겨찾기 대시보드",
+                subtitle: "자주 보는 메이플 캐릭터를 한눈에 정리하고 실시간으로 확인해 보세요.",
+                stats: {
+                    saved: "저장된 캐릭터",
+                    savedHelper: "빠르게 확인할 수 있도록 고정한 캐릭터 수",
+                    average: "평균 레벨",
+                    averageHelper: "즐겨찾기 캐릭터의 평균 레벨",
+                    focus: "현재 미리보기",
+                    focusHelper: "캐릭터를 선택하면 장비와 정보를 미리 볼 수 있어요",
+                    focusEmpty: "선택된 캐릭터가 없습니다",
+                },
+                list: {
+                    title: "즐겨찾기 목록",
+                    description: "카드를 눌러 미리보고 별 아이콘으로 즐겨찾기를 관리하세요.",
+                    totalLabel: "총 즐겨찾기",
+                    empty: "자주 보는 캐릭터를 저장하면 나만의 대시보드가 완성됩니다.",
+                },
+            },
             characterInfo: {
                 emptyState: "캐릭터를 선택해주세요",
                 detailButton: "상세 보기",


### PR DESCRIPTION
## Summary
- redesign the home dashboard container with a layered glassmorphism layout, quick stats, and a focus insight panel while keeping the existing theme
- drive the new structure with GSAP contexts for background accents, hero sections, and focus transitions
- refresh the mobile dialog styling to align with the updated dashboard presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb60c1b97c83248a82dd1ec18257d8