### PR TITLE
Set Korean default language with early storage sync

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,50 +58,63 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const RootLayout = ({ children }: Readonly<{ children: ReactNode }>) => {
     return (
-        <html lang="en" suppressHydrationWarning>
-        <body className={`${mapleStory.className} ${mapleStory.variable} antialiased`}>
-        {/* 테마 스크립트 (inline) */}
-        <Script id="theme-script" strategy="beforeInteractive">
-            {`
-                (() => {
-                  try {
-                    const t = localStorage.getItem('theme');
-                    if (t === 'dark') {
-                      document.documentElement.classList.add('dark');
-                    }
-                  } catch (e) {}
-                })();
-            `}
-        </Script>
+        <html lang="ko" suppressHydrationWarning>
+            <body className={`${mapleStory.className} ${mapleStory.variable} antialiased`}>
+                <Script id="language-script" strategy="beforeInteractive">
+                    {`
+                        (() => {
+                          try {
+                            const stored = localStorage.getItem('finder_language');
+                            const next = stored === 'en' || stored === 'ko' ? stored : 'ko';
+                            document.documentElement.lang = next;
+                          } catch (e) {
+                            document.documentElement.lang = 'ko';
+                          }
+                        })();
+                    `}
+                </Script>
+                {/* 테마 스크립트 (inline) */}
+                <Script id="theme-script" strategy="beforeInteractive">
+                    {`
+                        (() => {
+                          try {
+                            const t = localStorage.getItem('theme');
+                            if (t === 'dark') {
+                              document.documentElement.classList.add('dark');
+                            }
+                          } catch (e) {}
+                        })();
+                    `}
+                </Script>
 
-        {/* 넥슨 Analytics 스크립트 (외부 src) */}
-        <Script
-            src={`https://openapi.nexon.com/js/analytics.js?app_id=${process.env.NEXT_PUBLIC_NEXON_APP_ID}`}
-            strategy="afterInteractive"
-        />
+                {/* 넥슨 Analytics 스크립트 (외부 src) */}
+                <Script
+                    src={`https://openapi.nexon.com/js/analytics.js?app_id=${process.env.NEXT_PUBLIC_NEXON_APP_ID}`}
+                    strategy="afterInteractive"
+                />
 
-        {isProduction ? (
-            <Script id="pwa-service-worker" strategy="afterInteractive">
-                {`
-                    if ('serviceWorker' in navigator) {
-                      window.addEventListener('load', () => {
-                        navigator.serviceWorker.register('/service-worker.js').catch((error) => {
-                          console.error('Service worker registration failed:', error);
-                        });
-                      });
-                    }
-                `}
-            </Script>
-        ) : null}
+                {isProduction ? (
+                    <Script id="pwa-service-worker" strategy="afterInteractive">
+                        {`
+                            if ('serviceWorker' in navigator) {
+                              window.addEventListener('load', () => {
+                                navigator.serviceWorker.register('/service-worker.js').catch((error) => {
+                                  console.error('Service worker registration failed:', error);
+                                });
+                              });
+                            }
+                        `}
+                    </Script>
+                ) : null}
 
-        <LanguageProvider>
-            <AuthProvider>
-                <ViewTransition enter="fade" exit="fade">{children}</ViewTransition>
-                <MaintenanceDialog />
-                <Toaster />
-            </AuthProvider>
-        </LanguageProvider>
-        </body>
+                <LanguageProvider>
+                    <AuthProvider>
+                        <ViewTransition enter="fade" exit="fade">{children}</ViewTransition>
+                        <MaintenanceDialog />
+                        <Toaster />
+                    </AuthProvider>
+                </LanguageProvider>
+            </body>
         </html>
     );
 };

--- a/src/providers/LanguageProvider.tsx
+++ b/src/providers/LanguageProvider.tsx
@@ -14,37 +14,30 @@ type LanguageContextValue = {
 
 const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
 
-const detectBrowserLanguage = (): Language => {
-    if (typeof navigator === "undefined") return "en";
-    return navigator.language?.toLowerCase().startsWith("ko") ? "ko" : "en";
+const resolveInitialLanguage = (): Language => {
+    if (typeof window === "undefined") {
+        return "ko";
+    }
+
+    const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    if (stored === "ko" || stored === "en") {
+        return stored;
+    }
+
+    return "ko";
 };
 
 export const LanguageProvider = ({ children }: { children: React.ReactNode }) => {
-    const [language, setLanguageState] = useState<Language>("en");
-    const [initialized, setInitialized] = useState(false);
+    const [language, setLanguageState] = useState<Language>(resolveInitialLanguage);
 
     useEffect(() => {
-        if (typeof window === "undefined") return;
-        const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
-        if (stored === "ko" || stored === "en") {
-            setLanguageState(stored);
-        } else {
-            const detected = detectBrowserLanguage();
-            setLanguageState(detected);
-            window.localStorage.setItem(LANGUAGE_STORAGE_KEY, detected);
-        }
-        setInitialized(true);
-    }, []);
-
-    useEffect(() => {
-        if (!initialized) return;
         if (typeof document !== "undefined") {
             document.documentElement.lang = language;
         }
         if (typeof window !== "undefined") {
             window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
         }
-    }, [initialized, language]);
+    }, [language]);
 
     const setLanguage = useCallback((next: Language) => {
         setLanguageState(next);


### PR DESCRIPTION
## Summary
- default the document language to Korean and hydrate from stored preference before React renders
- load the language provider's initial state from storage with a Korean fallback and keep the storage/html lang in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb761fa1d483249cf8bda55138afe3