### PR TITLE
Add types for ability presets

### DIFF
--- a/src/interface/character/ICharacter.ts
+++ b/src/interface/character/ICharacter.ts
@@ -382,12 +382,22 @@ export interface ICharacterPropensity {
     charm_level: number
 }
 
+export interface IAbilityInfo {
+    ability_no: number
+    ability_grade: string
+    ability_value: string
+}
+
+export interface IAbilityPreset {
+    ability_grade: string
+    ability_info: IAbilityInfo[]
+}
+
 export interface ICharacterAbility {
     date: string
-    ability_preset_no: number
-    ability_info: {
-        ability_no: number
-        ability_grade: string
-        ability_value: string
-    }[]
+    ability_info: IAbilityInfo[]
+    ability_preset_1: IAbilityPreset | null
+    ability_preset_2: IAbilityPreset | null
+    ability_preset_3: IAbilityPreset | null
+    preset_no: number
 }


### PR DESCRIPTION
## Summary
- define reusable ability info and preset interfaces
- extend the character ability interface with preset fields for each ability preset and the active preset number

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb9ab153108324891f1a097e006c85