### PR TITLE
feat: add user api fetchers and routes

### DIFF
--- a/src/app/api/user/[endpoint]/route.ts
+++ b/src/app/api/user/[endpoint]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server";
+import axios, { AxiosError } from "axios";
+import { GetWithParams } from "@/utils/fetch";
+import { Failed, Success } from "@/utils/message";
+
+const endpointMap: Record<string, { url: string; successMessage: string }> = {
+    achievement: {
+        url: "https://open.api.nexon.com/maplestory/v1/user/achievement",
+        successMessage: "유저 업적 조회 성공",
+    },
+    ouid: {
+        url: "https://open.api.nexon.com/maplestory/v1/ouid",
+        successMessage: "계정 식별자 조회 성공",
+    },
+};
+
+export const GET = async (
+    req: NextRequest,
+    context: { params: Promise<{ endpoint: string }> }
+) => {
+    const apiKey =
+        req.headers.get("x-nxopen-api-key") || process.env.NEXT_PUBLIC_NEXON_API_KEY;
+
+    const handler = GetWithParams<
+        { endpoint: string } & Record<string, string>
+    >(async (params) => {
+        if (!apiKey) return Failed("Missing API Key", 500);
+
+        const { endpoint, ...query } = params;
+        const config = endpointMap[endpoint];
+
+        if (!config) {
+            return Failed("Unsupported user endpoint", 400);
+        }
+
+        try {
+            const res = await axios.get(config.url, {
+                params: query,
+                headers: { "x-nxopen-api-key": apiKey },
+            });
+
+            return Success(config.successMessage, 200, { data: res.data });
+        } catch (err: unknown) {
+            if (err instanceof AxiosError) {
+                const message =
+                    err.response?.data?.error?.message ?? err.message;
+                const status = err.response?.status ?? 500;
+                return Failed(message, status);
+            }
+            if (err instanceof Error) return Failed(err.message, 500);
+            return Failed("Unknown error", 500);
+        }
+    });
+
+    return handler(req, context);
+};

--- a/src/app/api/user/character/list/route.ts
+++ b/src/app/api/user/character/list/route.ts
@@ -1,13 +1,10 @@
 import axios, { AxiosError } from "axios";
-import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import { IUserAccountCharacterList } from "@/interface/user/IUserCharacterList";
 import { Get } from "@/utils/fetch";
 import { Failed, Success } from "@/utils/message";
 
 interface ICharacterListApiResponse {
-    account_list: {
-        account_id: string;
-        character_list: ICharacterSummary[];
-    }[];
+    account_list: IUserAccountCharacterList[];
 }
 
 export const GET = async (req: Request) => {
@@ -25,12 +22,16 @@ export const GET = async (req: Request) => {
                 }
             );
 
-            const characters = res.data.account_list.flatMap(
-                (account) => account.character_list
+            const accountList = res.data.account_list ?? [];
+            const characters = accountList.flatMap(
+                (account) => account.character_list ?? []
             );
 
             return Success("캐릭터 목록 조회 성공", 200, {
-                data: { characters },
+                data: {
+                    account_list: accountList,
+                    characters,
+                },
             });
         } catch (err: unknown) {
             if (err instanceof AxiosError) {
@@ -45,4 +46,3 @@ export const GET = async (req: Request) => {
 
     return handler(req);
 };
-

--- a/src/app/api/user/legacy/[endpoint]/route.ts
+++ b/src/app/api/user/legacy/[endpoint]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from "next/server";
+import axios, { AxiosError } from "axios";
+import { GetWithParams } from "@/utils/fetch";
+import { Failed, Success } from "@/utils/message";
+
+const legacyEndpointMap: Record<string, { url: string; successMessage: string }> = {
+    ouid: {
+        url: "https://open.api.nexon.com/maplestory/legacy/ouid",
+        successMessage: "레거시 계정 식별자 조회 성공",
+    },
+};
+
+export const GET = async (
+    req: NextRequest,
+    context: { params: Promise<{ endpoint: string }> }
+) => {
+    const apiKey =
+        req.headers.get("x-nxopen-api-key") || process.env.NEXT_PUBLIC_NEXON_API_KEY;
+
+    const handler = GetWithParams<
+        { endpoint: string } & Record<string, string>
+    >(async (params) => {
+        if (!apiKey) return Failed("Missing API Key", 500);
+
+        const { endpoint, ...query } = params;
+        const config = legacyEndpointMap[endpoint];
+
+        if (!config) {
+            return Failed("Unsupported legacy user endpoint", 400);
+        }
+
+        try {
+            const res = await axios.get(config.url, {
+                params: query,
+                headers: { "x-nxopen-api-key": apiKey },
+            });
+
+            return Success(config.successMessage, 200, { data: res.data });
+        } catch (err: unknown) {
+            if (err instanceof AxiosError) {
+                const message =
+                    err.response?.data?.error?.message ?? err.message;
+                const status = err.response?.status ?? 500;
+                return Failed(message, status);
+            }
+            if (err instanceof Error) return Failed(err.message, 500);
+            return Failed("Unknown error", 500);
+        }
+    });
+
+    return handler(req, context);
+};

--- a/src/fetchs/character.fetch.ts
+++ b/src/fetchs/character.fetch.ts
@@ -1,7 +1,6 @@
 import { createApiCaller, createRequestRunner, type ApiParams } from "@/fetchs/apiClient";
 import { ICharacterAbility, ICharacterAndroidEquipment, ICharacterBasic, ICharacterBeautyEquipment, ICharacterCashItemEquipment, ICharacterDojang, ICharacterHexaMatrix, ICharacterHexaMatrixStat, ICharacterHyperStat, ICharacterItemEquipment, ICharacterLinkSkill, ICharacterOtherStat, ICharacterPetEquipment, ICharacterPropensity, ICharacterSetEffect, ICharacterSkill, ICharacterStat, ICharacterSymbolEquipment, ICharacterVMatrix, IRingExchangeSkillEquipment, } from "@/interface/character/ICharacter";
 import { ICharacterResponse } from "@/interface/character/ICharacterResponse";
-import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
 
 const limitRunner = createRequestRunner({ concurrency: 5 });
 const callCharacterApiBase = createApiCaller({ basePath: "character", runner: limitRunner });
@@ -15,9 +14,6 @@ const callCharacterApi = <T>(
 
 const callApi = <T>(endpoint: string, params: ApiParams = {}): Promise<ICharacterResponse<T>> =>
     callGeneralApiBase<ICharacterResponse<T>>(endpoint, params);
-
-export const findCharacterList = () =>
-    callCharacterApi<{ characters: ICharacterSummary[] }>("list");
 
 /* ---------------- 기본 API ---------------- */
 export const findCharacterBasic = (ocid: string, date?: string) =>

--- a/src/fetchs/user.fetch.ts
+++ b/src/fetchs/user.fetch.ts
@@ -1,0 +1,27 @@
+import { createApiCaller, createRequestRunner, type ApiParams } from "@/fetchs/apiClient";
+import { IUserAchievement } from "@/interface/user/IUserAchievement";
+import { IUserCharacterList } from "@/interface/user/IUserCharacterList";
+import { IUserLegacyOuid, IUserOuid } from "@/interface/user/IUserOuid";
+import { IUserResponse } from "@/interface/user/IUserResponse";
+
+const userRunner = createRequestRunner({ concurrency: 5 });
+const callUserApiBase = createApiCaller({ basePath: "user", runner: userRunner });
+const callLegacyUserApiBase = createApiCaller({ basePath: "user/legacy", runner: userRunner });
+
+const callUserApi = <T>(endpoint: string, params: ApiParams = {}): Promise<IUserResponse<T>> =>
+    callUserApiBase<IUserResponse<T>>(endpoint, params);
+
+const callLegacyUserApi = <T>(endpoint: string, params: ApiParams = {}): Promise<IUserResponse<T>> =>
+    callLegacyUserApiBase<IUserResponse<T>>(endpoint, params);
+
+export const findUserCharacterList = () =>
+    callUserApi<IUserCharacterList>("character/list");
+
+export const findUserAchievement = (params: ApiParams = {}) =>
+    callUserApi<IUserAchievement>("achievement", params);
+
+export const findUserOuid = (params: ApiParams = {}) =>
+    callUserApi<IUserOuid>("ouid", params);
+
+export const findLegacyUserOuid = (params: ApiParams = {}) =>
+    callLegacyUserApi<IUserLegacyOuid>("ouid", params);

--- a/src/interface/user/IUserAchievement.ts
+++ b/src/interface/user/IUserAchievement.ts
@@ -1,0 +1,26 @@
+export interface IUserAchievementSummary {
+    trophy_id: number;
+    trophy_name: string;
+    trophy_grade: string;
+    trophy_score: number;
+    trophy_icon?: string;
+    trophy_description?: string;
+    trophy_condition?: string;
+    trophy_type?: string;
+    trophy_category_name?: string;
+    trophy_group_name?: string;
+    achieve_date?: string;
+}
+
+export interface IUserAchievement {
+    account_id?: string;
+    character_name?: string;
+    world_name?: string;
+    trophy_grade?: string;
+    trophy_score?: number;
+    next_grade_score?: number;
+    total_trophy_count?: number;
+    date?: string;
+    trophy_list?: IUserAchievementSummary[];
+    [key: string]: unknown;
+}

--- a/src/interface/user/IUserCharacterList.ts
+++ b/src/interface/user/IUserCharacterList.ts
@@ -1,0 +1,11 @@
+import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+
+export interface IUserAccountCharacterList {
+    account_id: string;
+    character_list: ICharacterSummary[];
+}
+
+export interface IUserCharacterList {
+    account_list: IUserAccountCharacterList[];
+    characters: ICharacterSummary[];
+}

--- a/src/interface/user/IUserOuid.ts
+++ b/src/interface/user/IUserOuid.ts
@@ -1,0 +1,7 @@
+export interface IUserOuid {
+    ouid: string;
+}
+
+export interface IUserLegacyOuid {
+    ouid: string;
+}

--- a/src/interface/user/IUserResponse.ts
+++ b/src/interface/user/IUserResponse.ts
@@ -1,0 +1,5 @@
+export interface IUserResponse<T> {
+    message: string;
+    status: number;
+    data: T;
+}

--- a/src/stores/characterListStore.ts
+++ b/src/stores/characterListStore.ts
@@ -1,8 +1,10 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { findCharacterBasic, findCharacterList } from "@/fetchs/character.fetch";
-import { ICharacterResponse } from "@/interface/character/ICharacterResponse";
+import { findCharacterBasic } from "@/fetchs/character.fetch";
+import { findUserCharacterList } from "@/fetchs/user.fetch";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import { IUserCharacterList } from "@/interface/user/IUserCharacterList";
+import { IUserResponse } from "@/interface/user/IUserResponse";
 
 type CharacterListSlice = {
     characters: ICharacterSummary[];
@@ -16,7 +18,7 @@ export const characterListStore = create<CharacterListSlice>()(persist((set) => 
         fetchCharacters: async () => {
             set({ loading: true });
             try {
-                const res: ICharacterResponse<{ characters: ICharacterSummary[] }> = await findCharacterList();
+                const res: IUserResponse<IUserCharacterList> = await findUserCharacterList();
                 const basicList = (res.data.characters ?? []).map((c) => ({
                     ocid: c.ocid,
                     character_name: c.character_name,


### PR DESCRIPTION
## Summary
- add user API routes for achievements, ouid lookups, and the account character list
- introduce user fetch utilities and interfaces to type responses from the new endpoints
- switch the character list store to use the new user fetcher and expose account list data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbaf7ff7fc83248461c0aa4342367e