### PR TITLE
Add MapleStory notice page and API integration

### DIFF
--- a/src/app/(main)/notice/page.tsx
+++ b/src/app/(main)/notice/page.tsx
@@ -1,0 +1,545 @@
+'use client';
+
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  findCashshopNoticeDetail,
+  findCashshopNoticeList,
+  findEventNoticeDetail,
+  findEventNoticeList,
+  findNoticeDetail,
+  findNoticeList,
+  findUpdateNoticeDetail,
+  findUpdateNoticeList,
+} from '@/fetchs/notice.fetch';
+import {
+  ICashshopNoticeArticle,
+  ICashshopNoticeDetail,
+  IEventNoticeArticle,
+  IEventNoticeDetail,
+  INoticeArticle,
+  INoticeDetail,
+} from '@/interface/notice/INotice';
+import { useTranslations } from '@/providers/LanguageProvider';
+
+type NoticeCategory = 'notice' | 'update' | 'event' | 'cashshop';
+
+type NoticeSummary = INoticeArticle | IEventNoticeArticle | ICashshopNoticeArticle;
+
+type NoticeDetailData = INoticeDetail | IEventNoticeDetail | ICashshopNoticeDetail;
+
+const initialDetailState = {
+  open: false,
+  loading: false,
+  category: null as NoticeCategory | null,
+  noticeId: null as number | null,
+  summary: null as NoticeSummary | null,
+  data: null as NoticeDetailData | null,
+  error: null as string | null,
+};
+
+const NoticePage = () => {
+  const t = useTranslations();
+  const isMountedRef = useRef(true);
+  const [activeTab, setActiveTab] = useState<NoticeCategory>('notice');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [noticeList, setNoticeList] = useState<INoticeArticle[]>([]);
+  const [updateList, setUpdateList] = useState<INoticeArticle[]>([]);
+  const [eventList, setEventList] = useState<IEventNoticeArticle[]>([]);
+  const [cashshopList, setCashshopList] = useState<ICashshopNoticeArticle[]>([]);
+  const [detailState, setDetailState] = useState(initialDetailState);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const loadNotices = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [noticeResponse, updateResponse, eventResponse, cashshopResponse] = await Promise.all([
+        findNoticeList(),
+        findUpdateNoticeList(),
+        findEventNoticeList(),
+        findCashshopNoticeList(),
+      ]);
+
+      if (!isMountedRef.current) return;
+
+      setNoticeList(noticeResponse.data.notice ?? []);
+      setUpdateList(updateResponse.data.update_notice ?? []);
+      setEventList(eventResponse.data.event_notice ?? []);
+      setCashshopList(cashshopResponse.data.cashshop_notice ?? []);
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (!isMountedRef.current) return;
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadNotices();
+  }, [loadNotices]);
+
+  const formatDateTime = useCallback(
+    (value: string | null | undefined) => {
+      if (!value) return t('notice.table.noData');
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return value;
+      }
+      return date.toLocaleString(undefined, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    },
+    [t],
+  );
+
+  const formatPeriod = useCallback(
+    (start: string | null | undefined, end: string | null | undefined) => {
+      if (!start && !end) return t('notice.table.noData');
+      const formattedStart = start ? formatDateTime(start) : null;
+      const formattedEnd = end ? formatDateTime(end) : null;
+
+      if (formattedStart && formattedEnd) {
+        return `${formattedStart} ~ ${formattedEnd}`;
+      }
+      if (formattedStart) {
+        return `${formattedStart} ~`;
+      }
+      if (formattedEnd) {
+        return `~ ${formattedEnd}`;
+      }
+      return t('notice.table.noData');
+    },
+    [formatDateTime, t],
+  );
+
+  const isOngoingSale = useCallback((flag: string | null | undefined) => {
+    if (typeof flag !== 'string') return false;
+    const normalized = flag.toLowerCase();
+    return normalized === 'true' || normalized === 'y' || normalized === 'yes';
+  }, []);
+
+  const resolveSaleStatus = useCallback(
+    (flag: string | null | undefined) => {
+      if (isOngoingSale(flag)) {
+        return t('notice.status.ongoing');
+      }
+      if (typeof flag === 'string') {
+        return t('notice.status.ended');
+      }
+      return t('notice.status.unknown');
+    },
+    [isOngoingSale, t],
+  );
+
+  const handleRetry = useCallback(() => {
+    void loadNotices();
+  }, [loadNotices]);
+
+  const handleSelectNotice = useCallback(
+    (category: NoticeCategory, summary: NoticeSummary) => {
+      setDetailState({
+        open: true,
+        loading: true,
+        category,
+        noticeId: summary.notice_id,
+        summary,
+        data: null,
+        error: null,
+      });
+
+      const loadDetail = async () => {
+        try {
+          let response: { data: NoticeDetailData };
+
+          switch (category) {
+            case 'notice':
+              response = await findNoticeDetail(summary.notice_id);
+              break;
+            case 'update':
+              response = await findUpdateNoticeDetail(summary.notice_id);
+              break;
+            case 'event':
+              response = await findEventNoticeDetail(summary.notice_id);
+              break;
+            case 'cashshop':
+              response = await findCashshopNoticeDetail(summary.notice_id);
+              break;
+            default:
+              return;
+          }
+
+          if (!isMountedRef.current) return;
+
+          setDetailState((prev) => {
+            if (
+              !prev.open ||
+              prev.noticeId !== summary.notice_id ||
+              prev.category !== category
+            ) {
+              return prev;
+            }
+            return {
+              ...prev,
+              loading: false,
+              data: response.data,
+              error: null,
+            };
+          });
+        } catch (err) {
+          if (!isMountedRef.current) return;
+
+          setDetailState((prev) => {
+            if (
+              !prev.open ||
+              prev.noticeId !== summary.notice_id ||
+              prev.category !== category
+            ) {
+              return prev;
+            }
+            return {
+              ...prev,
+              loading: false,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          });
+        }
+      };
+
+      void loadDetail();
+    },
+    [],
+  );
+
+  const handleDialogOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setDetailState({ ...initialDetailState });
+    }
+  }, []);
+
+  const sanitizedContents = useMemo(() => {
+    const contents = detailState.data?.contents;
+    if (!contents) return '';
+    if (typeof window === 'undefined') {
+      return contents;
+    }
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(contents, 'text/html');
+    doc.querySelectorAll('script, style').forEach((element) => element.remove());
+    doc.querySelectorAll('a').forEach((element) => {
+      element.setAttribute('target', '_blank');
+      element.setAttribute('rel', 'noopener noreferrer');
+    });
+    return doc.body.innerHTML;
+  }, [detailState.data?.contents]);
+
+  const renderList = (
+    category: NoticeCategory,
+    items: NoticeSummary[],
+    options?: {
+      renderHeaderCells?: () => ReactNode;
+      renderRowCells?: (item: NoticeSummary) => ReactNode;
+    },
+  ) => {
+    if (loading) {
+      return (
+        <div className="flex h-40 items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden="true" />
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="flex h-40 flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground">
+          <p>{t('notice.errors.list')}</p>
+          <p className="text-xs text-muted-foreground/70">{error}</p>
+          <Button variant="outline" size="sm" onClick={handleRetry}>
+            {t('notice.actions.retry')}
+          </Button>
+        </div>
+      );
+    }
+
+    if (!items.length) {
+      return (
+        <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+          {t('notice.table.empty')}
+        </div>
+      );
+    }
+
+    return (
+      <div className="overflow-hidden rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="min-w-[200px]">{t('notice.table.headers.title')}</TableHead>
+              <TableHead className="hidden w-48 text-right text-sm text-muted-foreground sm:table-cell">
+                {t('notice.table.headers.date')}
+              </TableHead>
+              {options?.renderHeaderCells ? options.renderHeaderCells() : null}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((item) => (
+              <TableRow
+                key={`${category}-${item.notice_id}`}
+                className="cursor-pointer"
+                onClick={() => handleSelectNotice(category, item)}
+              >
+                <TableCell>
+                  <div className="space-y-1">
+                    <p className="font-medium leading-snug text-foreground">{item.title}</p>
+                    <p className="text-xs text-muted-foreground sm:hidden">
+                      {formatDateTime(item.date)}
+                    </p>
+                    {category === 'event' ? (
+                      <p className="text-xs text-muted-foreground sm:hidden">
+                        {formatPeriod(
+                          (item as IEventNoticeArticle).date_event_start ?? null,
+                          (item as IEventNoticeArticle).date_event_end ?? null,
+                        )}
+                      </p>
+                    ) : null}
+                    {category === 'cashshop' ? (
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground sm:hidden">
+                        <span>
+                          {formatPeriod(
+                            (item as ICashshopNoticeArticle).date_sale_start ?? null,
+                            (item as ICashshopNoticeArticle).date_sale_end ?? null,
+                          )}
+                        </span>
+                        <Badge variant={isOngoingSale((item as ICashshopNoticeArticle).ongoing_flag) ? 'default' : 'outline'}>
+                          {resolveSaleStatus((item as ICashshopNoticeArticle).ongoing_flag)}
+                        </Badge>
+                      </div>
+                    ) : null}
+                  </div>
+                </TableCell>
+                <TableCell className="hidden w-48 text-sm text-muted-foreground sm:table-cell">
+                  {formatDateTime(item.date)}
+                </TableCell>
+                {options?.renderRowCells ? options.renderRowCells(item) : null}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    );
+  };
+
+  const renderUpdateList = () => renderList('update', updateList);
+  const renderNoticeList = () => renderList('notice', noticeList);
+
+  const renderEventList = () => {
+    return renderList('event', eventList, {
+      renderHeaderCells: () => (
+        <TableHead className="hidden min-w-[240px] text-right text-sm text-muted-foreground md:table-cell">
+          {t('notice.table.headers.period')}
+        </TableHead>
+      ),
+      renderRowCells: (item) => (
+        <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
+          {formatPeriod(
+            (item as IEventNoticeArticle).date_event_start ?? null,
+            (item as IEventNoticeArticle).date_event_end ?? null,
+          )}
+        </TableCell>
+      ),
+    });
+  };
+
+  const renderCashshopList = () => {
+    return renderList('cashshop', cashshopList, {
+      renderHeaderCells: () => (
+        <>
+          <TableHead className="hidden min-w-[240px] text-right text-sm text-muted-foreground lg:table-cell">
+            {t('notice.table.headers.salePeriod')}
+          </TableHead>
+          <TableHead className="hidden w-32 text-right text-sm text-muted-foreground lg:table-cell">
+            {t('notice.table.headers.status')}
+          </TableHead>
+        </>
+      ),
+      renderRowCells: (item) => (
+        <>
+          <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
+            {formatPeriod(
+              (item as ICashshopNoticeArticle).date_sale_start ?? null,
+              (item as ICashshopNoticeArticle).date_sale_end ?? null,
+            )}
+          </TableCell>
+          <TableCell className="hidden lg:table-cell">
+            <Badge variant={isOngoingSale((item as ICashshopNoticeArticle).ongoing_flag) ? 'default' : 'outline'}>
+              {resolveSaleStatus((item as ICashshopNoticeArticle).ongoing_flag)}
+            </Badge>
+          </TableCell>
+        </>
+      ),
+    });
+  };
+
+  const detailDate = detailState.data?.date ?? detailState.summary?.date ?? null;
+  const detailLink = detailState.data?.url ?? detailState.summary?.url ?? null;
+
+  const eventStart =
+    detailState.category === 'event'
+      ? (detailState.data as IEventNoticeDetail | null)?.date_event_start ??
+        (detailState.summary as IEventNoticeArticle | null)?.date_event_start ??
+        null
+      : null;
+  const eventEnd =
+    detailState.category === 'event'
+      ? (detailState.data as IEventNoticeDetail | null)?.date_event_end ??
+        (detailState.summary as IEventNoticeArticle | null)?.date_event_end ??
+        null
+      : null;
+
+  const saleStart =
+    detailState.category === 'cashshop'
+      ? (detailState.data as ICashshopNoticeDetail | null)?.date_sale_start ??
+        (detailState.summary as ICashshopNoticeArticle | null)?.date_sale_start ??
+        null
+      : null;
+  const saleEnd =
+    detailState.category === 'cashshop'
+      ? (detailState.data as ICashshopNoticeDetail | null)?.date_sale_end ??
+        (detailState.summary as ICashshopNoticeArticle | null)?.date_sale_end ??
+        null
+      : null;
+  const saleFlag =
+    detailState.category === 'cashshop'
+      ? (detailState.data as ICashshopNoticeDetail | null)?.ongoing_flag ??
+        (detailState.summary as ICashshopNoticeArticle | null)?.ongoing_flag ??
+        null
+      : null;
+
+  return (
+    <div className="flex h-full flex-col gap-6">
+      <Card className="flex-1 overflow-hidden">
+        <CardHeader className="border-b">
+          <CardTitle className="text-xl font-semibold">
+            {t('notice.title')}
+          </CardTitle>
+          <CardDescription>{t('notice.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex h-full flex-col gap-6 py-6">
+          <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as NoticeCategory)}>
+            <TabsList className="flex w-full flex-wrap gap-2">
+              <TabsTrigger value="notice" className="flex-1 sm:flex-none">
+                {t('notice.tabs.notice')}
+              </TabsTrigger>
+              <TabsTrigger value="update" className="flex-1 sm:flex-none">
+                {t('notice.tabs.update')}
+              </TabsTrigger>
+              <TabsTrigger value="event" className="flex-1 sm:flex-none">
+                {t('notice.tabs.event')}
+              </TabsTrigger>
+              <TabsTrigger value="cashshop" className="flex-1 sm:flex-none">
+                {t('notice.tabs.cashshop')}
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="notice" className="mt-4 space-y-4">
+              {renderNoticeList()}
+            </TabsContent>
+            <TabsContent value="update" className="mt-4 space-y-4">
+              {renderUpdateList()}
+            </TabsContent>
+            <TabsContent value="event" className="mt-4 space-y-4">
+              {renderEventList()}
+            </TabsContent>
+            <TabsContent value="cashshop" className="mt-4 space-y-4">
+              {renderCashshopList()}
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+
+      <Dialog open={detailState.open} onOpenChange={handleDialogOpenChange}>
+        <DialogContent className="sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle className="text-left text-lg font-semibold leading-tight">
+              {detailState.data?.title ?? detailState.summary?.title ?? t('notice.detail.loading')}
+            </DialogTitle>
+            <DialogDescription className="text-left text-sm text-muted-foreground">
+              {detailDate ? t('notice.detail.postedAt', { date: formatDateTime(detailDate) }) : null}
+            </DialogDescription>
+          </DialogHeader>
+
+          {detailState.category === 'event' ? (
+            <div className="text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">{t('notice.detail.eventPeriod')}:</span>{' '}
+              {formatPeriod(eventStart, eventEnd)}
+            </div>
+          ) : null}
+
+          {detailState.category === 'cashshop' ? (
+            <div className="flex flex-col gap-2 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <span className="font-medium text-foreground">{t('notice.detail.salePeriod')}:</span>{' '}
+                {formatPeriod(saleStart, saleEnd)}
+              </div>
+              <Badge variant={isOngoingSale(saleFlag) ? 'default' : 'outline'}>
+                {resolveSaleStatus(saleFlag)}
+              </Badge>
+            </div>
+          ) : null}
+
+          <ScrollArea className="mt-4 max-h-[60vh] rounded-md border">
+            <div className="p-4">
+              {detailState.loading ? (
+                <div className="flex h-40 items-center justify-center">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden="true" />
+                </div>
+              ) : detailState.error ? (
+                <div className="flex flex-col items-center gap-3 text-center text-sm text-muted-foreground">
+                  <p>{t('notice.detail.error')}</p>
+                  <p className="text-xs text-muted-foreground/70">{detailState.error}</p>
+                </div>
+              ) : detailState.data ? (
+                <div
+                  className="space-y-4 text-sm leading-relaxed [&_a]:text-primary [&_a]:underline [&_img]:h-auto [&_img]:max-w-full [&_table]:w-full [&_th]:border [&_td]:border [&_th]:px-2 [&_td]:px-2"
+                  dangerouslySetInnerHTML={{ __html: sanitizedContents }}
+                />
+              ) : (
+                <div className="flex h-40 items-center justify-center">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden="true" />
+                </div>
+              )}
+            </div>
+          </ScrollArea>
+
+          {detailLink ? (
+            <Button asChild variant="outline" className="mt-4 w-full sm:w-auto">
+              <a href={detailLink} target="_blank" rel="noopener noreferrer">
+                {t('notice.detail.openOriginal')}
+                <ExternalLink className="ml-2 h-4 w-4" aria-hidden="true" />
+              </a>
+            </Button>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default NoticePage;

--- a/src/app/api/notice/[endpoint]/route.ts
+++ b/src/app/api/notice/[endpoint]/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from "next/server";
+import axios, { AxiosError } from "axios";
+import { GetWithParams } from "@/utils/fetch";
+import { Failed, Success } from "@/utils/message";
+
+const endpointMap: Record<string, { url: string; successMessage: string }> = {
+    notice: {
+        url: "https://open.api.nexon.com/maplestory/v1/notice",
+        successMessage: "공지사항 조회 성공",
+    },
+    "notice-detail": {
+        url: "https://open.api.nexon.com/maplestory/v1/notice/detail",
+        successMessage: "공지사항 상세 조회 성공",
+    },
+    "notice-update": {
+        url: "https://open.api.nexon.com/maplestory/v1/notice-update",
+        successMessage: "업데이트 공지 조회 성공",
+    },
+    "notice-update-detail": {
+        url: "https://open.api.nexon.com/maplestory/v1/notice-update/detail",
+        successMessage: "업데이트 공지 상세 조회 성공",
+    },
+    "notice-event": {
+        url: "https://open.api.nexon.com/maplestory/v1/notice-event",
+        successMessage: "이벤트 공지 조회 성공",
+    },
+    "notice-event-detail": {
+        url: "https://open.api.nexon.com/maplestory/v1/notice-event/detail",
+        successMessage: "이벤트 공지 상세 조회 성공",
+    },
+    "notice-cashshop": {
+        url: "https://open.api.nexon.com/maplestory/v1/notice-cashshop",
+        successMessage: "캐시샵 공지 조회 성공",
+    },
+    "notice-cashshop-detail": {
+        url: "https://open.api.nexon.com/maplestory/v1/notice-cashshop/detail",
+        successMessage: "캐시샵 공지 상세 조회 성공",
+    },
+};
+
+export const GET = async (
+    req: NextRequest,
+    context: { params: Promise<{ endpoint: string }> },
+) => {
+    const apiKey =
+        req.headers.get("x-nxopen-api-key") || process.env.NEXT_PUBLIC_NEXON_API_KEY;
+
+    const handler = GetWithParams<
+        { endpoint: string } & Record<string, string>
+    >(async (params) => {
+        if (!apiKey) return Failed("Missing API Key", 500);
+
+        const { endpoint, ...query } = params;
+        const config = endpointMap[endpoint];
+
+        if (!config) {
+            return Failed("Unsupported notice endpoint", 400);
+        }
+
+        try {
+            const res = await axios.get(config.url, {
+                params: query,
+                headers: { "x-nxopen-api-key": apiKey },
+            });
+
+            return Success(config.successMessage, 200, { data: res.data });
+        } catch (err: unknown) {
+            if (err instanceof AxiosError) {
+                const message =
+                    err.response?.data?.error?.message ?? err.message;
+                const status = err.response?.status ?? 500;
+                return Failed(message, status);
+            }
+            if (err instanceof Error) return Failed(err.message, 500);
+            return Failed("Unknown error", 500);
+        }
+    });
+
+    return handler(req, context);
+};

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -49,6 +49,15 @@ const SideMenu = () => {
                             Search
                         </Button>
                     </SheetClose>
+                    <SheetClose asChild>
+                        <Button
+                            variant="ghost"
+                            className="w-full"
+                            onClick={() => router.push("/notice")}
+                        >
+                            Notice
+                        </Button>
+                    </SheetClose>
                     {!isGuest ? (
                         <SheetClose asChild>
                             <Button

--- a/src/constants/i18n/en.ts
+++ b/src/constants/i18n/en.ts
@@ -185,6 +185,47 @@ export const en = {
             title: "Info",
         },
     },
+    notice: {
+        title: "Official MapleStory notices",
+        description:
+            "Browse the latest announcements, update notes, event guides, and cash shop news in one place.",
+        tabs: {
+            notice: "Announcements",
+            update: "Updates",
+            event: "Events",
+            cashshop: "Cash Shop",
+        },
+        table: {
+            headers: {
+                title: "Title",
+                date: "Published",
+                period: "Event period",
+                salePeriod: "Sales period",
+                status: "Status",
+            },
+            empty: "No posts are available right now.",
+            noData: "—",
+        },
+        status: {
+            ongoing: "Ongoing",
+            ended: "Ended",
+            unknown: "Unknown",
+        },
+        detail: {
+            loading: "Loading notice...",
+            postedAt: "Posted on {date}",
+            eventPeriod: "Event period",
+            salePeriod: "Sales period",
+            error: "We couldn't load this notice.",
+            openOriginal: "Open original post",
+        },
+        errors: {
+            list: "We couldn't load the notices. Please try again.",
+        },
+        actions: {
+            retry: "Retry",
+        },
+    },
     authProvider: {
         toast: {
             logout: "You have been logged out.",

--- a/src/constants/i18n/ko.ts
+++ b/src/constants/i18n/ko.ts
@@ -179,6 +179,47 @@ export const ko = {
             title: "정보",
         },
     },
+    notice: {
+        title: "메이플스토리 공지 모음",
+        description:
+            "최근 공지사항, 업데이트 노트, 진행 중 이벤트, 캐시샵 소식을 한곳에서 확인하세요.",
+        tabs: {
+            notice: "공지사항",
+            update: "업데이트",
+            event: "이벤트",
+            cashshop: "캐시샵",
+        },
+        table: {
+            headers: {
+                title: "제목",
+                date: "등록일",
+                period: "이벤트 기간",
+                salePeriod: "판매 기간",
+                status: "상태",
+            },
+            empty: "등록된 게시글이 없습니다.",
+            noData: "—",
+        },
+        status: {
+            ongoing: "진행 중",
+            ended: "종료",
+            unknown: "정보 없음",
+        },
+        detail: {
+            loading: "공지 정보를 불러오는 중...",
+            postedAt: "{date}에 등록됨",
+            eventPeriod: "이벤트 기간",
+            salePeriod: "판매 기간",
+            error: "공지 내용을 불러오지 못했습니다.",
+            openOriginal: "원문 열기",
+        },
+        errors: {
+            list: "공지 목록을 불러오지 못했습니다. 다시 시도해 주세요.",
+        },
+        actions: {
+            retry: "다시 시도",
+        },
+    },
     authProvider: {
         toast: {
             logout: "로그아웃되었습니다.",

--- a/src/fetchs/notice.fetch.ts
+++ b/src/fetchs/notice.fetch.ts
@@ -1,0 +1,41 @@
+import { createApiCaller, createRequestRunner, type ApiParams } from "@/fetchs/apiClient";
+import {
+    ICashshopNoticeDetail,
+    ICashshopNoticeListPayload,
+    IEventNoticeDetail,
+    IEventNoticeListPayload,
+    INoticeDetail,
+    INoticeListPayload,
+    IUpdateNoticeDetail,
+    IUpdateNoticeListPayload,
+} from "@/interface/notice/INotice";
+import { INoticeResponse } from "@/interface/notice/INoticeResponse";
+
+const noticeRunner = createRequestRunner({ delayMs: 200 });
+const callNoticeApiBase = createApiCaller({ basePath: "notice", runner: noticeRunner });
+
+const callNoticeApi = <T>(endpoint: string, params: ApiParams = {}): Promise<INoticeResponse<T>> =>
+    callNoticeApiBase<INoticeResponse<T>>(endpoint, params);
+
+export const findNoticeList = () => callNoticeApi<INoticeListPayload>("notice");
+
+export const findNoticeDetail = (noticeId: number | string) =>
+    callNoticeApi<INoticeDetail>("notice-detail", { notice_id: noticeId });
+
+export const findUpdateNoticeList = () =>
+    callNoticeApi<IUpdateNoticeListPayload>("notice-update");
+
+export const findUpdateNoticeDetail = (noticeId: number | string) =>
+    callNoticeApi<IUpdateNoticeDetail>("notice-update-detail", { notice_id: noticeId });
+
+export const findEventNoticeList = () =>
+    callNoticeApi<IEventNoticeListPayload>("notice-event");
+
+export const findEventNoticeDetail = (noticeId: number | string) =>
+    callNoticeApi<IEventNoticeDetail>("notice-event-detail", { notice_id: noticeId });
+
+export const findCashshopNoticeList = () =>
+    callNoticeApi<ICashshopNoticeListPayload>("notice-cashshop");
+
+export const findCashshopNoticeDetail = (noticeId: number | string) =>
+    callNoticeApi<ICashshopNoticeDetail>("notice-cashshop-detail", { notice_id: noticeId });

--- a/src/interface/notice/INotice.ts
+++ b/src/interface/notice/INotice.ts
@@ -1,0 +1,53 @@
+export interface INoticeArticle {
+    title: string;
+    url: string;
+    notice_id: number;
+    date: string;
+}
+
+export type INoticeListPayload = {
+    notice: INoticeArticle[];
+};
+
+export type INoticeDetail = {
+    title: string;
+    url: string;
+    contents: string;
+    date: string;
+};
+
+export type IUpdateNoticeListPayload = {
+    update_notice: INoticeArticle[];
+};
+
+export type IUpdateNoticeDetail = INoticeDetail;
+
+export interface IEventNoticeArticle extends INoticeArticle {
+    date_event_start: string | null;
+    date_event_end: string | null;
+}
+
+export type IEventNoticeListPayload = {
+    event_notice: IEventNoticeArticle[];
+};
+
+export interface IEventNoticeDetail extends INoticeDetail {
+    date_event_start: string | null;
+    date_event_end: string | null;
+}
+
+export interface ICashshopNoticeArticle extends INoticeArticle {
+    date_sale_start: string | null;
+    date_sale_end: string | null;
+    ongoing_flag: string | null;
+}
+
+export type ICashshopNoticeListPayload = {
+    cashshop_notice: ICashshopNoticeArticle[];
+};
+
+export interface ICashshopNoticeDetail extends INoticeDetail {
+    date_sale_start: string | null;
+    date_sale_end: string | null;
+    ongoing_flag: string | null;
+}

--- a/src/interface/notice/INoticeResponse.ts
+++ b/src/interface/notice/INoticeResponse.ts
@@ -1,0 +1,5 @@
+import { SuccessType } from "@/types/MessageType";
+
+export type INoticeResponse<T> = SuccessType & {
+    data: T;
+};

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -16,10 +16,17 @@ const isPublicPath = (pathname: string) =>
     pathname === "/" || pathname === "/sign_in" || pathname === "/sign_up";
 
 export const isGuestAccessiblePath = (pathname: string) =>
-    pathname === "/" || pathname === "/search" || pathname === "/chat" || pathname.startsWith("/character/");
+    pathname === "/" ||
+    pathname === "/search" ||
+    pathname === "/chat" ||
+    pathname === "/notice" ||
+    pathname.startsWith("/character/");
 
 export const isUnauthenticatedAccessiblePath = (pathname: string) =>
-    pathname === "/" || pathname === "/search" || pathname.startsWith("/character/");
+    pathname === "/" ||
+    pathname === "/search" ||
+    pathname === "/notice" ||
+    pathname.startsWith("/character/");
 
 type AuthContextValue = {
     status: AuthStatus;


### PR DESCRIPTION
## Summary
- define notice interfaces and fetch helpers for Nexon notice APIs
- add guest-accessible /notice page with announcement tabs and detail dialog
- expose notice API proxy route, translations, and navigation link

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbbfa45d088324a83b46410cfa095d