### PR TITLE
Restrict guest access to cube/starforce history pages

### DIFF
--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -1,20 +1,68 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Menu } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
+    Bell,
+    Box,
+    Home,
+    LogOut,
+    Menu,
+    MessageSquare,
+    Search,
+    Sparkles,
+    UserCircle,
+    Users,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetClose, SheetContent, SheetDescription, SheetHeader as SheetContentHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import {
+    Sheet,
+    SheetClose,
+    SheetContent,
+    SheetDescription,
+    SheetHeader as SheetContentHeader,
+    SheetTitle,
+    SheetTrigger,
+} from "@/components/ui/sheet";
 import { useAuth } from "@/providers/AuthProvider";
+
+type MenuItem = {
+    href: string;
+    label: string;
+    icon: LucideIcon;
+    hideForGuest?: boolean;
+    requiresAuth?: boolean;
+};
+
+const menuItems: MenuItem[] = [
+    { href: "/home", label: "Home", icon: Home, hideForGuest: true },
+    { href: "/search", label: "Search", icon: Search },
+    { href: "/notice", label: "Notice", icon: Bell },
+    { href: "/character_list", label: "Character List", icon: Users, hideForGuest: true },
+    { href: "/chat", label: "Finder Chat", icon: MessageSquare },
+    { href: "/starforce", label: "Starforce History", icon: Sparkles, requiresAuth: true },
+    { href: "/cube", label: "Cube History", icon: Box, requiresAuth: true },
+    { href: "/my_page", label: "My Page", icon: UserCircle, hideForGuest: true },
+];
 
 const SideMenu = () => {
     const router = useRouter();
-    const { status, logout } = useAuth();
-    const isGuest = status === "guest";
+    const { status, isGuest, isAuthenticated, logout } = useAuth();
 
     const handleLogout = async () => {
         await logout();
         router.push("/");
     };
+
+    const availableItems = menuItems.filter((item) => {
+        if (item.requiresAuth && !isAuthenticated) {
+            return false;
+        }
+        if (item.hideForGuest && isGuest) {
+            return false;
+        }
+        return true;
+    });
 
     return (
         <Sheet>
@@ -29,74 +77,27 @@ const SideMenu = () => {
                     <SheetDescription>menu</SheetDescription>
                 </SheetContentHeader>
                 <div className="mt-4 space-y-2">
-                    {!isGuest ? (
-                        <SheetClose asChild>
+                    {availableItems.map((item) => (
+                        <SheetClose asChild key={item.href}>
                             <Button
                                 variant="ghost"
-                                className="w-full"
-                                onClick={() => router.push("/home")}
+                                className="w-full justify-start gap-3"
+                                onClick={() => router.push(item.href)}
                             >
-                                Home
+                                <item.icon className="h-4 w-4" aria-hidden="true" />
+                                <span>{item.label}</span>
                             </Button>
                         </SheetClose>
-                    ) : null}
-                    <SheetClose asChild>
-                        <Button
-                            variant="ghost"
-                            className="w-full"
-                            onClick={() => router.push("/search")}
-                        >
-                            Search
-                        </Button>
-                    </SheetClose>
-                    <SheetClose asChild>
-                        <Button
-                            variant="ghost"
-                            className="w-full"
-                            onClick={() => router.push("/notice")}
-                        >
-                            Notice
-                        </Button>
-                    </SheetClose>
-                    {!isGuest ? (
-                        <SheetClose asChild>
-                            <Button
-                                variant="ghost"
-                                className="w-full"
-                                onClick={() => router.push("/character_list")}
-                            >
-                                Character List
-                            </Button>
-                        </SheetClose>
-                    ) : null}
-                    <SheetClose asChild>
-                        <Button
-                            variant="ghost"
-                            className="w-full"
-                            onClick={() => router.push("/chat")}
-                        >
-                            Finder Chat
-                        </Button>
-                    </SheetClose>
-                    {!isGuest ? (
-                        <SheetClose asChild>
-                            <Button
-                                variant="ghost"
-                                className="w-full"
-                                onClick={() => router.push("/my_page")}
-                            >
-                                My Page
-                            </Button>
-                        </SheetClose>
-                    ) : null}
+                    ))}
                     {status !== "unauthenticated" ? (
                         <SheetClose asChild>
                             <Button
                                 variant="ghost"
-                                className="w-full"
+                                className="w-full justify-start gap-3"
                                 onClick={handleLogout}
                             >
-                                {status === "guest" ? "Exit Guest" : "Logout"}
+                                <LogOut className="h-4 w-4" aria-hidden="true" />
+                                <span>{status === "guest" ? "Exit Guest" : "Logout"}</span>
                             </Button>
                         </SheetClose>
                     ) : null}

--- a/src/components/character/detail/CharacterMenu.tsx
+++ b/src/components/character/detail/CharacterMenu.tsx
@@ -1,24 +1,21 @@
-import { useRouter } from "next/navigation"
-import { Box, Ellipsis, Images, Star } from "lucide-react"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, } from "@/components/ui/dropdown-menu"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { useTranslations } from "@/providers/LanguageProvider"
+import { useRouter } from "next/navigation";
+import { Ellipsis, Images } from "lucide-react";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useTranslations } from "@/providers/LanguageProvider";
 
 const CharacterMenu = () => {
-    const router = useRouter()
-    const t = useTranslations()
+    const router = useRouter();
+    const t = useTranslations();
 
     const getFigure = () => {
         router.push("/figure");
-    }
-
-    const getStarforce = () => {
-        router.push("/starforce");
-    }
-
-    const getCube = () => {
-        router.push("/cube");
-    }
+    };
 
     return (
         <DropdownMenu>
@@ -29,24 +26,16 @@ const CharacterMenu = () => {
             </DropdownMenuTrigger>
 
             <DropdownMenuContent align="end" className="w-36">
-                {/* Starforce */}
-                <DropdownMenuItem onClick={getStarforce} className="flex gap-2 hover:cursor-pointer">
-                    <Star size={14} />
-                    <span>{t("character.banner.starforce")}</span>
-                </DropdownMenuItem>
-
-                {/* Cube */}
-                <DropdownMenuItem onClick={getCube} className="flex gap-2 hover:cursor-pointer">
-                    <Box size={14} />
-                    <span>{t("character.banner.cube")}</span>
-                </DropdownMenuItem>
-
-                {/* Figure */}
                 <Tooltip>
                     <TooltipTrigger asChild>
-                        <DropdownMenuItem onClick={getFigure} className="flex gap-2 hover:cursor-pointer">
+                        <DropdownMenuItem
+                            onClick={getFigure}
+                            className="flex gap-2 hover:cursor-pointer"
+                        >
                             <Images size={14} />
-                            <span className='text-muted-foreground'>{t("character.banner.figure")}</span>
+                            <span className="text-muted-foreground">
+                                {t("character.banner.figure")}
+                            </span>
                         </DropdownMenuItem>
                     </TooltipTrigger>
                     <TooltipContent side="bottom" sideOffset={4}>
@@ -55,7 +44,7 @@ const CharacterMenu = () => {
                 </Tooltip>
             </DropdownMenuContent>
         </DropdownMenu>
-    )
-}
+    );
+};
 
-export default CharacterMenu
+export default CharacterMenu;

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -19,16 +19,12 @@ export const isGuestAccessiblePath = (pathname: string) =>
     pathname === "/" ||
     pathname === "/search" ||
     pathname === "/chat" ||
-    pathname === "/starforce" ||
-    pathname === "/cube" ||
     pathname === "/notice" ||
     pathname.startsWith("/character/");
 
 export const isUnauthenticatedAccessiblePath = (pathname: string) =>
     pathname === "/" ||
     pathname === "/search" ||
-    pathname === "/starforce" ||
-    pathname === "/cube" ||
     pathname === "/notice" ||
     pathname.startsWith("/character/");
 


### PR DESCRIPTION
## Summary
- remove cube and starforce entries from the character detail menu
- add cube and starforce shortcuts with icons to the global side menu and gate them behind authentication
- tighten guest and unauthenticated route guards for the history pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbc7f8e7e8832486f52cc39f9ecf5c