### PR TITLE
Fix notice list loading spinner after data fetch

### DIFF
--- a/src/app/(main)/notice/page.tsx
+++ b/src/app/(main)/notice/page.tsx
@@ -63,13 +63,15 @@ const initialDetailState = {
 
 const NoticePage = () => {
   const t = useTranslations();
-  const isMountedRef = useRef(true);
+  const isMountedRef = useRef(false);
   const [activeTab, setActiveTab] = useState<NoticeCategory>('notice');
   const [listStates, setListStates] = useState<NoticeListStates>(() => createInitialListStates());
   const listStatesRef = useRef(listStates);
   const [detailState, setDetailState] = useState(initialDetailState);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
     return () => {
       isMountedRef.current = false;
     };


### PR DESCRIPTION
## Summary
- reset the notice page mounted ref when the component mounts so async updates run after React strict-mode remounts
- allow notice list/detail requests to clear the loading flag once data is received so the spinner stops

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbdf19e7e883248baed29d2499b149