### PR TITLE
Adjust detail views for responsive scaling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,7 @@
     color-scheme: light;
     --radius: 0.65rem;
     --header-height: 3rem;
+    --adaptive-font-size: clamp(14px, calc(8px + 1.2vmin), 18px);
     --background: oklch(1 0 0);
     --foreground: oklch(0.141 0.005 285.823);
     --card: oklch(1 0 0);
@@ -122,6 +123,7 @@
     }
 
     body {
+        font-size: var(--adaptive-font-size);
         @apply bg-background text-foreground;
     }
 }

--- a/src/components/character/CharacterBanner.tsx
+++ b/src/components/character/CharacterBanner.tsx
@@ -50,7 +50,10 @@ const CharacterBanner = ({
     const rankingLabel = overallRanking ? t('character.banner.ranking', {value: overallRanking.ranking.toLocaleString(),}) : null;
 
     return (
-        <Card className={cn("relative h-60 sm:h-64 w-full overflow-hidden rounded", backgroundColor)}>
+        <Card
+            className={cn("relative w-full overflow-hidden rounded", backgroundColor)}
+            style={{ height: "clamp(14rem, 36vmin, 20rem)" }}
+        >
             {backgroundImage && (
                 <Image
                     src={backgroundImage}
@@ -110,22 +113,30 @@ const CharacterBanner = ({
                         </div>
                         {bannerImageSrc && (
                             <div
-                                className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+                                className="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center"
                                 style={{
                                     transform: `scale(${imageScale})`,
                                     opacity: imageScale,
                                     ...(imageTransitionName ? { viewTransitionName: imageTransitionName } : {}),
                                 }}
                             >
-                                <Image
-                                    src={bannerImageSrc}
-                                    alt={basic?.character_name ?? "character"}
-                                    width={120}
-                                    height={120}
-                                    className="object-contain h-auto"
-                                    priority
-                                    unoptimized
-                                />
+                                <div
+                                    className="relative"
+                                    style={{
+                                        width: "clamp(7rem, calc(5rem + 4vmin), 10rem)",
+                                        height: "clamp(7rem, calc(5rem + 4vmin), 10rem)",
+                                    }}
+                                >
+                                    <Image
+                                        src={bannerImageSrc}
+                                        alt={basic?.character_name ?? "character"}
+                                        fill
+                                        className="h-full w-full object-contain"
+                                        priority
+                                        sizes="(max-width: 768px) 45vw, 18vw"
+                                        unoptimized
+                                    />
+                                </div>
                             </div>
                         )}
                     </>

--- a/src/components/character/CharacterDetail.tsx
+++ b/src/components/character/CharacterDetail.tsx
@@ -392,7 +392,11 @@ const CharacterDetail = ({ ocid }: { ocid: string }) => {
                                             width={SMALL_IMAGE_SIZE}
                                             height={SMALL_IMAGE_SIZE}
                                             className="object-contain transition-opacity h-auto"
-                                            style={{ opacity: smallImageOpacity }}
+                                            sizes="(max-width: 768px) 20vw, 6vw"
+                                            style={{
+                                                opacity: smallImageOpacity,
+                                                width: "clamp(2.4rem, calc(2rem + 0.9vmin), 3.25rem)",
+                                            }}
                                         />
                                     )}
                                     <div

--- a/src/components/character/item/ItemEquipDetail.tsx
+++ b/src/components/character/item/ItemEquipDetail.tsx
@@ -43,7 +43,14 @@ const ItemEquipDetail = ({ item }: ItemEquipDetailProps) => {
     const star = item.item_starforce_option || {};
 
     return (
-        <div className="bg-black/85 text-white rounded-lg shadow-lg p-4 min-w-64">
+        <div
+            className="bg-black/85 text-white rounded-lg shadow-lg w-full max-w-[min(22rem,90vw)]"
+            style={{
+                padding: "clamp(1rem, calc(1rem + 0.5vmin), 1.75rem)",
+                fontSize: "clamp(0.8rem, calc(0.75rem + 0.2vmin), 1rem)",
+                lineHeight: "clamp(1.35, calc(1.2 + 0.25vmin), 1.6)",
+            }}
+        >
             <div className="flex items-center gap-3 mb-2">
                 {/* 아이템 아이콘 */}
                 <div className="relative w-10 h-10 flex-shrink-0">

--- a/src/components/character/item/ItemEquipments.tsx
+++ b/src/components/character/item/ItemEquipments.tsx
@@ -46,14 +46,30 @@ const slotPosition: Record<string, { col: number; row: number }> = {
 
 const ItemEquipments = ({ items = [], loading }: IEquipmentGrid) => {
     const t = useTranslations();
+    const slotSize = "clamp(2.4rem, calc(2.1rem + 1.1vmin), 3.5rem)";
+    const slotPadding = "clamp(0.35rem, calc(0.25rem + 0.35vmin), 0.6rem)";
+    const iconSize = "clamp(1.8rem, calc(1.55rem + 0.6vmin), 2.8rem)";
+    const gridGap = "clamp(0.35rem, calc(0.3rem + 0.35vmin), 0.75rem)";
+    const gridPadding = "clamp(0.75rem, calc(0.5rem + 0.4vmin), 1.5rem)";
 
     return (
         <Card className="w-full">
             <CardHeader>
                 <CardTitle>{t("character.item.equipment.title")}</CardTitle>
             </CardHeader>
-            <CardContent className="flex w-full justify-center px-2 sm:px-6">
-                <div className="grid grid-cols-5 grid-rows-6 gap-1.5 sm:gap-2 p-2 sm:p-4 bg-muted rounded-lg w-fit">
+            <CardContent
+                className="flex w-full justify-center"
+                style={{
+                    paddingInline: "clamp(0.5rem, calc(0.5rem + 0.5vmin), 2rem)",
+                }}
+            >
+                <div
+                    className="grid grid-cols-5 grid-rows-6 bg-muted rounded-lg w-fit"
+                    style={{
+                        gap: gridGap,
+                        padding: gridPadding,
+                    }}
+                >
                     {Object.entries(slotPosition).map(([slot, pos]) => {
                         const equip = items.find((item) => item.item_equipment_slot === slot);
 
@@ -62,15 +78,22 @@ const ItemEquipments = ({ items = [], loading }: IEquipmentGrid) => {
                                 <Popover key={slot}>
                                     <PopoverTrigger asChild>
                                         <div
-                                            className="w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 p-2 border rounded-md flex items-center justify-center bg-card cursor-pointer hover:shadow-md"
-                                            style={{ gridColumnStart: pos.col, gridRowStart: pos.row }}
+                                            className="border rounded-md flex items-center justify-center bg-card cursor-pointer hover:shadow-md"
+                                            style={{
+                                                gridColumnStart: pos.col,
+                                                gridRowStart: pos.row,
+                                                width: slotSize,
+                                                height: slotSize,
+                                                padding: slotPadding,
+                                            }}
                                         >
                                             <Image
                                                 src={equip.item_icon}
                                                 alt={equip.item_name}
                                                 width={48}
                                                 height={48}
-                                                className="w-8 h-auto sm:w-10 md:w-12"
+                                                className="h-auto"
+                                                style={{ width: iconSize }}
                                                 priority
                                             />
                                         </div>
@@ -89,10 +112,19 @@ const ItemEquipments = ({ items = [], loading }: IEquipmentGrid) => {
                         return (
                             <div
                                 key={slot}
-                                className="w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 p-2 border rounded-md flex items-center justify-center bg-card"
-                                style={{ gridColumnStart: pos.col, gridRowStart: pos.row }}
+                                className="border rounded-md flex items-center justify-center bg-card"
+                                style={{
+                                    gridColumnStart: pos.col,
+                                    gridRowStart: pos.row,
+                                    width: slotSize,
+                                    height: slotSize,
+                                    padding: slotPadding,
+                                }}
                             >
-                                <Skeleton className="w-6 h-6 sm:w-8 sm:h-8 md:w-10 md:h-10"/>
+                                <Skeleton
+                                    className="h-full w-full"
+                                    style={{ maxWidth: iconSize, maxHeight: iconSize }}
+                                />
                             </div>
                         );
                     })}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -30,7 +30,7 @@ const PopoverContent = ({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-[min(22rem,90vw)] origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
- scale global font sizing with a viewport-aware clamp so rem-based spacing grows or shrinks with the screen
- update the character banner and sticky preview avatar to size images using clamp/vmin measurements for smoother scaling
- make equipment detail popovers responsive by using clamp-based dimensions and a flexible popover width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc25991f648324b71e838e89331ada