### PR TITLE
Redesign home and character list dashboards

### DIFF
--- a/src/app/(main)/character_list/page.tsx
+++ b/src/app/(main)/character_list/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { unstable_ViewTransition as ViewTransition, useCallback, useEffect, useMemo, useState } from "react";
+import { Filter, Search, Star, Users } from "lucide-react";
 import { toast } from "sonner";
 import { characterListStore } from "@/stores/characterListStore";
 import { favoriteStore } from "@/stores/favoriteStore";
@@ -13,12 +14,16 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Skeleton } from "@/components/ui/skeleton";
 import { addFavorite, getFavorites, removeFavorite } from "@/fetchs/favorite.fetch";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import { useTranslations } from "@/providers/LanguageProvider";
+
+const ALL_WORLDS_VALUE = "all";
 
 const CharacterList = () => {
+    const t = useTranslations();
     const setApiKey = userStore((s) => s.setApiKey);
     const { characters, loading, fetchCharacters } = characterListStore();
     const [displayCharacters, setDisplayCharacters] = useState<ICharacterSummary[]>([]);
-    const [worldFilter, setWorldFilter] = useState("전체월드");
+    const [worldFilter, setWorldFilter] = useState(ALL_WORLDS_VALUE);
     const [searchKeyword, setSearchKeyword] = useState("");
     const { favorites, setFavorites, addFavorite: addFavoriteOcid, removeFavorite: removeFavoriteOcid } = favoriteStore();
     const [userId, setUserId] = useState<string | null>(null);
@@ -55,7 +60,7 @@ const CharacterList = () => {
     useEffect(() => {
         const keyword = searchKeyword.trim().toLowerCase();
         const filtered = characters.filter((c) => {
-            const matchesWorld = worldFilter === "전체월드" || c.world_name === worldFilter;
+            const matchesWorld = worldFilter === ALL_WORLDS_VALUE || c.world_name === worldFilter;
             const matchesKeyword = c.character_name.toLowerCase().includes(keyword);
 
             return matchesWorld && matchesKeyword;
@@ -75,63 +80,169 @@ const CharacterList = () => {
     }, [userId, favorites, addFavoriteOcid, removeFavoriteOcid]);
 
     const worlds = useMemo(
-        () => ["전체월드", ...Array.from(new Set(characters.map((c) => c.world_name)))],
+        () => [ALL_WORLDS_VALUE, ...Array.from(new Set(characters.map((c) => c.world_name)))],
         [characters],
+    );
+    const filteredCount = displayCharacters.length;
+    const selectedWorldLabel = worldFilter === ALL_WORLDS_VALUE ? t('characterList.filters.world.all') : worldFilter;
+    const stats = useMemo(
+        () => [
+            {
+                key: 'total' as const,
+                label: t('characterList.stats.total'),
+                value: characters.length.toLocaleString(),
+                helper: t('characterList.stats.totalHelper'),
+                Icon: Users,
+            },
+            {
+                key: 'filtered' as const,
+                label: t('characterList.stats.filtered'),
+                value: filteredCount.toLocaleString(),
+                helper: t('characterList.stats.filteredHelper', { world: selectedWorldLabel }),
+                Icon: Filter,
+            },
+            {
+                key: 'favorites' as const,
+                label: t('characterList.stats.favorites'),
+                value: favorites.length.toLocaleString(),
+                helper: t('characterList.stats.favoritesHelper', { count: favorites.length }),
+                Icon: Star,
+            },
+        ],
+        [characters.length, favorites.length, filteredCount, selectedWorldLabel, t],
     );
 
     return (
-        <div className="flex h-[calc(100vh-var(--header-height))] flex-col">
-            {/* 서버 선택 */}
-            <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                {loading ? (
-                    <Skeleton className="h-10 w-[180px]" />
-                ) : (
-                    <Select value={worldFilter} onValueChange={setWorldFilter}>
-                        <SelectTrigger className="w-[180px]">
-                            <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {worlds.map((world) => (
-                                <SelectItem key={world} value={world}>
-                                    {world}
-                                </SelectItem>
+        <ViewTransition enter="fade" exit="fade">
+            <div className="flex h-full flex-col gap-6">
+                <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-primary/10 via-background to-background p-6 shadow-sm">
+                    <div className="absolute -left-24 top-1/2 hidden h-56 w-56 -translate-y-1/2 rounded-full bg-primary/20 blur-3xl md:block" aria-hidden />
+                    <div className="absolute -right-20 -top-10 hidden h-48 w-48 rounded-full bg-primary/10 blur-3xl lg:block" aria-hidden />
+                    <div className="relative flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+                        <div className="space-y-3">
+                            <span className="inline-flex w-fit items-center rounded-full border border-border/60 bg-background/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+                                {t('characterList.header.badge')}
+                            </span>
+                            <h1 className="text-3xl font-semibold leading-tight text-foreground sm:text-4xl">
+                                {t('characterList.header.title')}
+                            </h1>
+                            <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+                                {t('characterList.header.description')}
+                            </p>
+                        </div>
+                        <div className="grid w-full gap-3 sm:max-w-2xl sm:grid-cols-3">
+                            {stats.map(({ key, label, value, helper, Icon }) => (
+                                <div key={key} className="rounded-2xl border border-border/60 bg-background/70 p-4 shadow-sm">
+                                    <div className="flex items-center gap-3">
+                                        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+                                            <Icon className="h-4 w-4" />
+                                        </div>
+                                        <div>
+                                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                                {label}
+                                            </p>
+                                            <p className="text-xl font-semibold text-foreground">{value}</p>
+                                        </div>
+                                    </div>
+                                    <p className="mt-3 text-xs text-muted-foreground">{helper}</p>
+                                </div>
                             ))}
-                        </SelectContent>
-                    </Select>
-                )}
-                {loading ? (
-                    <Skeleton className="h-10 w-full sm:w-[240px]" />
-                ) : (
-                    <Input
-                        value={searchKeyword}
-                        onChange={(e) => setSearchKeyword(e.target.value)}
-                        placeholder="캐릭터 이름 검색"
-                        className="w-full sm:w-[240px]"
-                    />
-                )}
-            </div>
-
-            {loading ? (
-                <div className="grid flex-1 grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
-                    {Array.from({ length: 6 }).map((_, i) => (
-                        <CharacterCardSkeleton key={i} />
-                    ))}
-                </div>
-            ) : (
-                <div className="w-full flex-1 overflow-y-auto rounded-md border">
-                    <div className="grid grid-cols-1 gap-4 p-2 sm:grid-cols-2 md:grid-cols-3">
-                        {displayCharacters.map((character) => (
-                            <CharacterCell
-                                key={character.ocid}
-                                character={character}
-                                favorites={favorites}
-                                toggleFavorite={toggleFavorite}
-                            />
-                        ))}
+                        </div>
                     </div>
-                </div>
-            )}
-        </div>
+                </section>
+
+                <section className="flex flex-1 flex-col overflow-hidden rounded-3xl border border-border/60 bg-background/80 shadow-sm backdrop-blur">
+                    <div className="border-b border-border/60 px-6 py-5">
+                        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                            <div className="space-y-1">
+                                <h2 className="text-lg font-semibold text-foreground">{t('characterList.list.title')}</h2>
+                                <p className="text-sm text-muted-foreground">{t('characterList.list.description')}</p>
+                            </div>
+                            <div className="grid gap-3 sm:grid-cols-[minmax(0,220px)_minmax(0,1fr)] sm:items-end lg:w-[500px]">
+                                <div className="space-y-2">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                        {t('characterList.filters.world.label')}
+                                    </p>
+                                    {loading ? (
+                                        <Skeleton className="h-12 w-full rounded-xl" />
+                                    ) : (
+                                        <Select value={worldFilter} onValueChange={setWorldFilter}>
+                                            <SelectTrigger
+                                                className="h-12 w-full rounded-xl border-border/60 bg-background/80 px-5 text-sm shadow-sm"
+                                                aria-label={t('characterList.filters.world.label')}
+                                            >
+                                                <SelectValue placeholder={t('characterList.filters.world.label')} />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {worlds.map((world) => (
+                                                    <SelectItem key={world} value={world}>
+                                                        {world === ALL_WORLDS_VALUE
+                                                            ? t('characterList.filters.world.all')
+                                                            : world}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    )}
+                                </div>
+                                <div className="space-y-2">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                        {t('characterList.filters.search.label')}
+                                    </p>
+                                    {loading ? (
+                                        <Skeleton className="h-12 w-full rounded-xl" />
+                                    ) : (
+                                        <div className="relative">
+                                            <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                            <Input
+                                                value={searchKeyword}
+                                                onChange={(e) => setSearchKeyword(e.target.value)}
+                                                placeholder={t('characterList.filters.search.placeholder')}
+                                                className="h-12 w-full rounded-xl border-border/60 bg-background/80 pl-11 pr-4 text-sm shadow-sm"
+                                                aria-label={t('characterList.filters.search.label')}
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="flex-1 overflow-hidden">
+                        {loading ? (
+                            <div className="grid h-full grid-cols-1 gap-4 overflow-y-auto p-6 sm:grid-cols-2 lg:grid-cols-3">
+                                {Array.from({ length: 6 }).map((_, i) => (
+                                    <CharacterCardSkeleton key={i} />
+                                ))}
+                            </div>
+                        ) : filteredCount === 0 ? (
+                            <div className="flex h-full flex-col items-center justify-center gap-4 px-6 py-12 text-center">
+                                <div className="rounded-2xl border border-dashed border-border/60 bg-muted/20 px-6 py-10 shadow-sm">
+                                    <h3 className="text-base font-semibold text-foreground">
+                                        {t('characterList.empty.title')}
+                                    </h3>
+                                    <p className="mt-2 max-w-md text-sm text-muted-foreground">
+                                        {t('characterList.empty.description')}
+                                    </p>
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="h-full overflow-y-auto px-2 pb-6">
+                                <div className="grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+                                    {displayCharacters.map((character) => (
+                                        <CharacterCell
+                                            key={character.ocid}
+                                            character={character}
+                                            favorites={favorites}
+                                            toggleFavorite={toggleFavorite}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </section>
+            </div>
+        </ViewTransition>
     );
 };
 

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useRouter } from "next/navigation";
-import { unstable_ViewTransition as ViewTransition, useEffect, useState } from "react";
+import { unstable_ViewTransition as ViewTransition, useEffect, useMemo, useState } from "react";
+import { Bookmark, UserRound } from "lucide-react";
 import { favoriteStore } from "@/stores/favoriteStore";
 import { supabase } from "@/libs/supabaseClient";
 import CharacterInfo from "@/components/home/CharacterInfo";
@@ -21,6 +22,41 @@ const Home = () => {
     const [selected, setSelected] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
     const [open, setOpen] = useState(false);
+    const selectedCharacter = useMemo(
+        () => favorites.find((favorite) => favorite.ocid === selected) ?? null,
+        [favorites, selected],
+    );
+    const stats = useMemo(
+        () => {
+            const favoritesCount = favorites.length;
+            const favoritesHelper = favoritesCount > 0
+                ? t('home.stats.totalFavoritesHelper', { count: favoritesCount })
+                : t('home.stats.totalFavoritesHelperEmpty');
+            const selectedHelper = selectedCharacter
+                ? `${selectedCharacter.character_class} · ${t('home.stats.level', {
+                    level: selectedCharacter.character_level,
+                })}`
+                : t('home.stats.selectedHelper');
+
+            return [
+                {
+                    key: 'favorites' as const,
+                    label: t('home.stats.totalFavorites'),
+                    value: favoritesCount.toLocaleString(),
+                    helper: favoritesHelper,
+                    Icon: Bookmark,
+                },
+                {
+                    key: 'selected' as const,
+                    label: t('home.stats.selected'),
+                    value: selectedCharacter?.character_name ?? t('home.stats.none'),
+                    helper: selectedHelper,
+                    Icon: UserRound,
+                },
+            ];
+        },
+        [favorites.length, selectedCharacter, t],
+    );
 
     useEffect(() => {
         const load = async () => {
@@ -104,37 +140,75 @@ const Home = () => {
 
     return (
         <ViewTransition enter="fade" exit="fade">
-            <div className="flex h-full">
-                {/* 캐릭터 목록 */}
-                <FavoriteList
-                    favorites={favorites}
-                    loading={loading}
-                    onSelect={handleSelect}
-                    onToggleFavorite={toggleFavorite}
-                />
+            <div className="flex h-full flex-col gap-6">
+                <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-primary/10 via-background to-background p-6 shadow-sm">
+                    <div className="absolute -right-24 top-1/2 hidden h-56 w-56 -translate-y-1/2 rounded-full bg-primary/30 blur-3xl md:block" aria-hidden />
+                    <div className="relative flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+                        <div className="space-y-3">
+                            <span className="inline-flex w-fit items-center rounded-full border border-border/60 bg-background/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+                                {t('home.hero.badge')}
+                            </span>
+                            <h1 className="text-3xl font-semibold leading-tight text-foreground sm:text-4xl">
+                                {t('home.hero.title')}
+                            </h1>
+                            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+                                {t('home.hero.description')}
+                            </p>
+                        </div>
+                        <div className="grid w-full gap-3 sm:max-w-lg sm:grid-cols-2">
+                            {stats.map(({ key, label, value, helper, Icon }) => (
+                                <div key={key} className="rounded-2xl border border-border/60 bg-background/70 p-4 shadow-sm">
+                                    <div className="flex items-center gap-3">
+                                        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+                                            <Icon className="h-4 w-4" />
+                                        </div>
+                                        <div>
+                                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                                {label}
+                                            </p>
+                                            <p className="text-xl font-semibold text-foreground">{value}</p>
+                                        </div>
+                                    </div>
+                                    <p className="mt-3 text-xs text-muted-foreground">{helper}</p>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </section>
 
-                {/* 캐릭터 정보 */}
-                <CharacterInfo ocid={selected} goToDetailPage={goToDetailPage} />
+                <div className="flex flex-1 flex-col gap-6 xl:flex-row">
+                    <section className="flex h-full flex-col overflow-hidden rounded-3xl border border-border/60 bg-background/80 shadow-sm backdrop-blur xl:w-[360px]">
+                        <div className="border-b border-border/60 px-6 py-5">
+                            <h2 className="text-lg font-semibold text-foreground">{t('home.favorites.title')}</h2>
+                            <p className="text-sm text-muted-foreground">{t('home.favorites.description')}</p>
+                        </div>
+                        <FavoriteList
+                            favorites={favorites}
+                            loading={loading}
+                            onSelect={handleSelect}
+                            onToggleFavorite={toggleFavorite}
+                            className="h-full"
+                            emptyLabel={t('home.favorites.empty')}
+                        />
+                    </section>
 
-                {/* 모바일 다이얼로그 */}
+                    <div className="hidden flex-1 overflow-hidden rounded-3xl border border-border/60 bg-background/80 shadow-sm backdrop-blur md:flex">
+                        <CharacterInfo ocid={selected} goToDetailPage={goToDetailPage} className="h-full" />
+                    </div>
+                </div>
+
                 <Dialog open={open} onOpenChange={setOpen}>
-                    <DialogContent
-                        className="
-                            fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                            w-[90vw] max-w-md max-h-[90vh] overflow-y-auto
-                            rounded-2xl bg-background p-0 shadow-lg
-                        "
-                    >
-                        <DialogTitle className="px-4 pt-4">{t('home.dialog.title')}</DialogTitle>
+                    <DialogContent className="max-h-[85vh] w-[90vw] max-w-lg overflow-hidden rounded-3xl border border-border/60 bg-background/95 p-0 shadow-2xl backdrop-blur">
+                        <DialogTitle className="px-6 pt-6 text-base font-semibold">
+                            {t('home.dialog.title')}
+                        </DialogTitle>
                         <CharacterInfo
                             ocid={selected}
                             goToDetailPage={goToDetailPage}
-                            className="flex md:hidden max-h-[80vh]"
+                            className="flex max-h-[70vh] flex-1 md:hidden"
                         />
                     </DialogContent>
-
                 </Dialog>
-
             </div>
         </ViewTransition>
     );

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -6,6 +6,7 @@ import WorldIcon from "@/components/common/WorldIcon";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import { cn } from "@/utils/utils";
 
 interface ICharacterCardProps {
     character: ICharacterSummary;
@@ -22,63 +23,62 @@ const CharacterCard = ({
 }: ICharacterCardProps) => {
     return (
         <Card
-            className={`p-4 flex flex-col relative w-full ${onSelect ? "cursor-pointer" : ""}`}
+            className={cn(
+                "group relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-border/60 bg-card/80 p-5 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-lg",
+                onSelect && "cursor-pointer",
+            )}
             onClick={onSelect}
         >
-            {/* 서버 정보 */}
-            <div className="absolute top-2 left-2 z-10 flex items-center gap-1">
-                <WorldIcon name={character.world_name} />
-                <span className="text-xs sm:text-sm md:text-base">
-                    {character.world_name}
-                </span>
-            </div>
-
-            {/* 즐겨찾기 버튼 */}
-            <div className="absolute top-2 right-2 z-10">
+            <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    <WorldIcon name={character.world_name} />
+                    <span className="truncate">{character.world_name}</span>
+                </div>
                 <Button
                     variant="ghost"
+                    className="h-9 w-9 rounded-full border border-border/60 bg-background/80 p-0 text-muted-foreground shadow-sm transition-colors hover:bg-primary/10 hover:text-primary"
                     onClick={(e) => {
                         e.preventDefault();
-                        e.stopPropagation(); // 부모 onClick 방지
+                        e.stopPropagation();
                         onToggleFavorite?.();
                     }}
+                    aria-label="Toggle favorite"
                 >
                     <Star
-                        className={`h-5 w-5 ${
-                            isFavorite ? "text-yellow-400" : "text-muted-foreground"
-                        }`}
+                        className={cn("h-4 w-4 transition-colors", isFavorite && "text-primary")}
                         fill={isFavorite ? "currentColor" : "none"}
                     />
                 </Button>
             </div>
 
-            {/* 캐릭터 이미지 */}
-            <div className="relative w-full aspect-[4/3] flex items-center justify-center">
+            <div className="relative mt-6 flex aspect-[4/3] items-center justify-center overflow-hidden rounded-2xl border border-dashed border-border/40 bg-muted/20">
                 {character.image && (
                     <Image
                         src={`/api/crop?url=${encodeURIComponent(character.image)}`}
                         alt={character.character_name}
-                        className="object-contain translate-y-4 h-auto"
-                        width={100}
-                        height={100}
+                        className="h-full w-auto max-h-full object-contain transition duration-300 group-hover:scale-105"
+                        width={160}
+                        height={160}
                         priority
                     />
                 )}
             </div>
 
-            {/* 캐릭터 정보 */}
-            <div className="mt-auto flex items-end justify-between min-h-[64px] sm:min-h-[72px] md:min-h-[80px]">
-                <div className="truncate max-w-[70%]">
-                    <p className="font-bold text-sm sm:text-base md:text-lg lg:text-xl">
+            <div className="mt-6 flex items-end justify-between gap-4">
+                <div className="min-w-0">
+                    <p className="truncate text-lg font-semibold text-foreground">
                         {character.character_name}
                     </p>
-                    <p className="text-xs sm:text-sm md:text-base text-muted-foreground truncate">
+                    <p className="truncate text-sm text-muted-foreground">
                         {character.character_class}
                     </p>
                 </div>
-                <p className="text-red-500 font-bold text-lg sm:text-xl md:text-2xl lg:text-3xl shrink-0 ml-2">
-                    {character.character_level}
-                </p>
+                <div className="flex flex-col items-end">
+                    <span className="text-xs font-semibold uppercase text-muted-foreground">Lv.</span>
+                    <span className="text-2xl font-semibold text-primary">
+                        {character.character_level}
+                    </span>
+                </div>
             </div>
         </Card>
     );

--- a/src/components/character/CharacterCardSkeleton.tsx
+++ b/src/components/character/CharacterCardSkeleton.tsx
@@ -3,23 +3,23 @@
 import { Card } from '@/components/ui/card';
 
 const CharacterCardSkeleton = () => (
-    <Card className="p-4 flex flex-col w-full relative">
-        {/* 서버 정보 Skeleton */}
-        <div className="absolute top-2 left-2 flex items-center gap-1">
-            <div className="w-5 h-5 bg-muted animate-pulse rounded-full" />
-            <div className="h-3 w-16 bg-muted animate-pulse rounded" />
+    <Card className="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-border/60 bg-card/80 p-5 shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2">
+                <div className="h-5 w-5 animate-pulse rounded-full bg-muted" />
+                <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+            </div>
+            <div className="h-9 w-9 rounded-full border border-border/60 bg-muted/40" />
         </div>
 
-        {/* 캐릭터 이미지 Skeleton (비율 고정) */}
-        <div className="relative w-full aspect-[4/3] mb-4 bg-muted animate-pulse rounded-md" />
+        <div className="mt-6 aspect-[4/3] w-full rounded-2xl bg-muted/30" />
 
-        {/* 캐릭터 정보 Skeleton */}
-        <div className="mt-auto flex items-end justify-between min-h-[64px] sm:min-h-[72px] md:min-h-[80px]">
-            <div className="space-y-2 w-[70%]">
-                <div className="h-4 bg-muted animate-pulse rounded w-3/4" />
-                <div className="h-3 bg-muted animate-pulse rounded w-1/2" />
+        <div className="mt-6 flex items-end justify-between gap-4">
+            <div className="w-2/3 space-y-3">
+                <div className="h-5 w-full animate-pulse rounded bg-muted/70" />
+                <div className="h-4 w-3/4 animate-pulse rounded bg-muted/60" />
             </div>
-            <div className="h-6 sm:h-7 md:h-8 lg:h-10 bg-muted animate-pulse rounded w-16" />
+            <div className="h-10 w-12 animate-pulse rounded bg-muted/70" />
         </div>
     </Card>
 );

--- a/src/components/home/CharacterInfo.tsx
+++ b/src/components/home/CharacterInfo.tsx
@@ -71,91 +71,102 @@ const CharacterInfo = ({ ocid, goToDetailPage, className }: ICharacterInfoProps)
     }, [basic?.character_image]);
 
     return (
-        <ScrollArea className={cn("hidden md:flex flex-1", className)}>
-            {!ocid ? (
-                <div className="flex justify-center items-center w-full h-page animate-pulse">
-                    {t('home.characterInfo.emptyState')}
-                </div>
-            ) : (
-                <div className="p-4 max-w-6xl mx-auto">
-                    <div className="flex flex-col lg:flex-row gap-10">
-                        <section className="lg:flex-[0.4] flex flex-col items-center max-w-[300px] mx-auto">
-                            <div className="self-start flex items-center gap-2 text-xl">
-                                {loading || !basic ? (
-                                    <>
-                                        <Skeleton className="w-6 h-6 rounded-full" />
-                                        <Skeleton className="h-6 w-24" />
-                                    </>
-                                ) : (
-                                    <>
-                                        <WorldIcon name={basic.world_name} />
-                                        {basic.world_name}
-                                    </>
-                                )}
-                            </div>
+        <ScrollArea className={cn("hidden h-full flex-1 md:flex", className)}>
+            <div className="mx-auto flex h-full w-full max-w-6xl flex-col gap-6 p-6">
+                {!ocid ? (
+                    <div className="flex flex-1 items-center justify-center">
+                        <div className="rounded-3xl border border-dashed border-border/60 bg-muted/20 px-8 py-12 text-center text-sm text-muted-foreground">
+                            {t('home.characterInfo.emptyState')}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="relative overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-primary/10 via-background to-background p-6 shadow-sm">
+                        <div className="absolute -right-24 top-1/2 hidden h-64 w-64 -translate-y-1/2 rounded-full bg-primary/30 blur-3xl xl:block" aria-hidden />
+                        <div className="relative flex flex-col gap-6 xl:flex-row">
+                            <section className="flex flex-col items-center gap-5 text-center xl:w-72 xl:items-start xl:text-left">
+                                <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                                    {loading || !basic ? (
+                                        <>
+                                            <Skeleton className="h-6 w-6 rounded-full" />
+                                            <Skeleton className="h-4 w-24" />
+                                        </>
+                                    ) : (
+                                        <>
+                                            <WorldIcon name={basic.world_name} />
+                                            <span>{basic.world_name}</span>
+                                        </>
+                                    )}
+                                </div>
 
-                            {loading || !basic ? (
-                                <Skeleton className="w-64 h-64 mt-4" />
-                            ) : (
-                                characterImageSrc && (
-                                    <div
-                                        className="w-64 h-64 mt-4 flex items-center justify-center"
-                                        style={imageTransitionName ? { viewTransitionName: imageTransitionName } : undefined}
-                                    >
-                                        <Image
-                                            src={characterImageSrc}
-                                            alt={basic.character_name}
-                                            className="object-contain h-auto"
-                                            width={100}
-                                            height={100}
-                                            priority
-                                        />
-                                    </div>
-                                )
-                            )}
+                                <div className="relative aspect-square w-52 max-w-full overflow-hidden rounded-2xl border border-border/40 bg-background/70 p-6 shadow-inner">
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-full w-full" />
+                                    ) : (
+                                        characterImageSrc && (
+                                            <div
+                                                className="flex h-full w-full items-center justify-center"
+                                                style={imageTransitionName ? { viewTransitionName: imageTransitionName } : undefined}
+                                            >
+                                                <Image
+                                                    src={characterImageSrc}
+                                                    alt={basic.character_name}
+                                                    className="h-full w-auto max-h-full object-contain"
+                                                    width={200}
+                                                    height={200}
+                                                    priority
+                                                />
+                                            </div>
+                                        )
+                                    )}
+                                </div>
 
-                            {loading || !basic ? (
-                                <Skeleton className="h-8 w-40 mt-4" />
-                            ) : (
-                                <h2 className="text-2xl font-bold mt-4 text-center lg:text-left">
-                                    {basic.character_name}
-                                </h2>
-                            )}
+                                <div className="space-y-1">
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-8 w-40" />
+                                    ) : (
+                                        <h2 className="text-3xl font-semibold tracking-tight text-foreground">
+                                            {basic.character_name}
+                                        </h2>
+                                    )}
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-5 w-32" />
+                                    ) : (
+                                        <p className="text-sm text-muted-foreground">
+                                            {basic.character_class}
+                                        </p>
+                                    )}
+                                </div>
 
-                            {loading || !basic ? (
-                                <Skeleton className="h-6 w-32" />
-                            ) : (
-                                <p className="text-center lg:text-left text-muted-foreground">
-                                    {basic.character_class}
-                                </p>
-                            )}
+                                <div className="flex items-center justify-center gap-2 xl:justify-start">
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-8 w-24" />
+                                    ) : (
+                                        <span className="rounded-full bg-primary/10 px-4 py-1 text-sm font-semibold text-primary">
+                                            {t('home.stats.level', { level: basic.character_level })}
+                                        </span>
+                                    )}
+                                </div>
 
-                            {loading || !basic ? (
-                                <Skeleton className="h-6 w-24" />
-                            ) : (
-                                <p className="text-center lg:text-left font-bold text-red-500">
-                                    Lv. {basic.character_level}
-                                </p>
-                            )}
+                                <div className="flex w-full justify-center xl:justify-start">
+                                    {loading || !basic ? (
+                                        <Skeleton className="h-10 w-28" />
+                                    ) : (
+                                        <Button onClick={goToDetailPage} className="rounded-full px-6">
+                                            {t('home.characterInfo.detailButton')}
+                                        </Button>
+                                    )}
+                                </div>
+                            </section>
 
-                            <div className="flex justify-center">
-                                {loading || !basic ? (
-                                    <Skeleton className="h-10 w-20" />
-                                ) : (
-                                    <Button onClick={goToDetailPage}>{t('home.characterInfo.detailButton')}</Button>
-                                )}
-                            </div>
-                        </section>
-
-                        {/* 우측: 장비 */}
-                        <div className="lg:flex-[0.6] flex justify-center">
-                            <div className="mx-auto max-w-[360px] md:max-w-[420px]">
-                                <ItemEquipments items={items} loading={loading || !basic} />
+                            <div className="flex flex-1 items-stretch">
+                                <div className="w-full max-w-xl xl:ml-auto">
+                                    <ItemEquipments items={items} loading={loading || !basic} />
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-            )}
+                )}
+            </div>
         </ScrollArea>
     );
 };

--- a/src/components/home/FavoriteList.tsx
+++ b/src/components/home/FavoriteList.tsx
@@ -4,21 +4,32 @@ import CharacterCard from "@/components/character/CharacterCard";
 import CharacterCardSkeleton from "@/components/character/CharacterCardSkeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
+import { cn } from "@/utils/utils";
 
 interface IFavoriteListProps {
     favorites: ICharacterSummary[];
     loading: boolean;
     onSelect: (ocid: string) => void;
     onToggleFavorite: (ocid: string) => void;
+    className?: string;
+    emptyLabel?: string;
 }
 
-const FavoriteList = ({ favorites, loading, onSelect, onToggleFavorite }: IFavoriteListProps) => {
+const FavoriteList = ({
+    favorites,
+    loading,
+    onSelect,
+    onToggleFavorite,
+    className,
+    emptyLabel = "",
+}: IFavoriteListProps) => {
     return (
-        <ScrollArea className="w-full md:w-1/3 md:border-r p-4">
-            <div className="space-y-4">
-                {loading
-                    ? Array.from({ length: 3 }).map((_, i) => <CharacterCardSkeleton key={i} />)
-                    : favorites.map((c) => (
+        <ScrollArea className={cn("h-full", className)}>
+            <div className="space-y-4 px-5 py-5">
+                {loading ? (
+                    Array.from({ length: 3 }).map((_, i) => <CharacterCardSkeleton key={i} />)
+                ) : favorites.length > 0 ? (
+                    favorites.map((c) => (
                         <CharacterCard
                             key={c.ocid}
                             character={c}
@@ -26,7 +37,12 @@ const FavoriteList = ({ favorites, loading, onSelect, onToggleFavorite }: IFavor
                             onToggleFavorite={() => onToggleFavorite(c.ocid)}
                             onSelect={() => onSelect(c.ocid)}
                         />
-                    ))}
+                    ))
+                ) : (
+                    <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-dashed border-border/60 bg-muted/20 px-6 py-10 text-center text-sm text-muted-foreground">
+                        {emptyLabel}
+                    </div>
+                )}
             </div>
         </ScrollArea>
     );

--- a/src/constants/i18n/en.ts
+++ b/src/constants/i18n/en.ts
@@ -177,12 +177,68 @@ export const en = {
         },
     },
     home: {
+        hero: {
+            badge: "Favorites dashboard",
+            title: "Keep your favourites close",
+            description:
+                "Browse the characters you pinned and jump to detailed stats whenever you need them.",
+        },
+        stats: {
+            totalFavorites: "Saved favourites",
+            totalFavoritesHelper: "{count} characters are pinned for quick access.",
+            totalFavoritesHelperEmpty: "Pin a character to keep it ready for quick access.",
+            selected: "Current selection",
+            selectedHelper: "Choose a character from the list to preview gear instantly.",
+            level: "Lv. {level}",
+            none: "—",
+        },
+        favorites: {
+            title: "Favourite characters",
+            description: "Pick a character from the list to see an instant preview of their equipment.",
+            empty: "No favourites yet. Add a character to your favourites to display it here.",
+        },
         characterInfo: {
             emptyState: "Please choose your character",
             detailButton: "Detail",
         },
         dialog: {
             title: "Info",
+        },
+    },
+    characterList: {
+        header: {
+            badge: "Roster overview",
+            title: "Manage your MapleStory roster",
+            description:
+                "Filter the characters linked to your account and open their detailed pages in a single click.",
+        },
+        stats: {
+            total: "Synced characters",
+            filtered: "Visible with filters",
+            favorites: "Saved favourites",
+            totalHelper: "Characters fetched from your linked account.",
+            filteredHelper: "Filtered by {world}.",
+            favoritesHelper: "{count} favourites saved across the app.",
+        },
+        filters: {
+            title: "Filters",
+            description: "Choose a world or search by name to narrow down the list.",
+            world: {
+                label: "World",
+                all: "All worlds",
+            },
+            search: {
+                label: "Search",
+                placeholder: "Search character name...",
+            },
+        },
+        list: {
+            title: "Character overview",
+            description: "Select a card to open the full character detail page.",
+        },
+        empty: {
+            title: "No characters match your filters",
+            description: "Try selecting another world or refresh the sync to load your roster again.",
         },
     },
     notice: {

--- a/src/constants/i18n/ko.ts
+++ b/src/constants/i18n/ko.ts
@@ -171,12 +171,66 @@ export const ko = {
         },
     },
     home: {
+        hero: {
+            badge: "즐겨찾기 대시보드",
+            title: "즐겨찾는 캐릭터를 한눈에",
+            description: "자주 확인하는 캐릭터를 등록하고 장비 정보를 빠르게 확인하세요.",
+        },
+        stats: {
+            totalFavorites: "등록된 즐겨찾기",
+            totalFavoritesHelper: "즐겨찾기에 {count}명의 캐릭터가 등록되어 있습니다.",
+            totalFavoritesHelperEmpty: "즐겨찾기를 추가하면 여기에서 빠르게 확인할 수 있어요.",
+            selected: "선택된 캐릭터",
+            selectedHelper: "목록에서 캐릭터를 선택하면 장비 미리보기를 볼 수 있습니다.",
+            level: "Lv. {level}",
+            none: "—",
+        },
+        favorites: {
+            title: "내 즐겨찾기",
+            description: "목록에서 캐릭터를 선택해 장비 요약을 확인하세요.",
+            empty: "즐겨찾기에 등록된 캐릭터가 없습니다.",
+        },
         characterInfo: {
             emptyState: "캐릭터를 선택해주세요",
             detailButton: "상세 보기",
         },
         dialog: {
             title: "정보",
+        },
+    },
+    characterList: {
+        header: {
+            badge: "캐릭터 현황",
+            title: "보유 캐릭터 관리",
+            description: "계정과 연동된 캐릭터를 필터링하고 한 번의 클릭으로 상세 페이지로 이동하세요.",
+        },
+        stats: {
+            total: "연동된 캐릭터",
+            filtered: "필터 적용 결과",
+            favorites: "즐겨찾기",
+            totalHelper: "계정과 연동된 캐릭터 수입니다.",
+            filteredHelper: "{world} 기준으로 표시 중입니다.",
+            favoritesHelper: "앱 전반에서 {count}명의 즐겨찾기를 사용할 수 있어요.",
+        },
+        filters: {
+            title: "필터",
+            description: "월드를 선택하거나 이름을 검색해 목록을 좁혀보세요.",
+            world: {
+                label: "월드",
+                all: "전체 월드",
+            },
+            search: {
+                label: "검색",
+                placeholder: "캐릭터 이름을 검색하세요",
+            },
+        },
+        list: {
+            title: "캐릭터 목록",
+            description: "카드를 선택하면 상세 정보를 확인할 수 있습니다.",
+        },
+        empty: {
+            title: "조건에 맞는 캐릭터가 없습니다",
+            description: "다른 월드를 선택하거나 계정 연동 상태를 다시 확인해 주세요.",
         },
     },
     notice: {


### PR DESCRIPTION
## Summary
- restyle the home dashboard with hero metrics, refreshed favorite list, and updated character preview layout
- refresh the character list page with a themed header, improved filters, and richer empty/loading states
- align shared character cards and translations to support the new UI copy in both languages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc275d3d28832495d7ca4a9fb00f0f