### PR TITLE
Improve equipment UI responsiveness

### DIFF
--- a/src/components/character/item/ItemEquipDetail.tsx
+++ b/src/components/character/item/ItemEquipDetail.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import type { CSSProperties } from "react";
 import RenderOptionRow from "@/components/character/item/renderOptionRow";
 import { getGradeColor } from "@/constants/option_grade_color.constant";
 import { IItemEquipment } from "@/interface/character/ICharacter";
@@ -10,6 +11,13 @@ interface ItemEquipDetailProps {
 
 const ItemEquipDetail = ({ item }: ItemEquipDetailProps) => {
     const t = useTranslations();
+    const panelStyle: CSSProperties = {
+        width: "min(18rem, calc(100vw - 3rem))",
+    };
+    const iconStyle: CSSProperties = {
+        width: "clamp(2.25rem, 8vw, 3rem)",
+        height: "clamp(2.25rem, 8vw, 3rem)",
+    };
 
     const mainOptions: [string, string, string | undefined][] = [
         ["STR", "str", item.item_total_option?.str],
@@ -43,29 +51,32 @@ const ItemEquipDetail = ({ item }: ItemEquipDetailProps) => {
     const star = item.item_starforce_option || {};
 
     return (
-        <div className="bg-black/85 text-white rounded-lg shadow-lg p-4 min-w-64">
-            <div className="flex items-center gap-3 mb-2">
+        <div
+            className="bg-black/85 text-white rounded-lg shadow-lg p-3 sm:p-4"
+            style={panelStyle}
+        >
+            <div className="flex items-center gap-3 mb-3 sm:mb-4">
                 {/* 아이템 아이콘 */}
-                <div className="relative w-10 h-10 flex-shrink-0">
+                <div className="relative flex-shrink-0" style={iconStyle}>
                     <Image
                         src={item.item_icon}
                         alt={item.item_name}
                         fill
                         className="object-contain"
-                        sizes="40px"
+                        sizes="(max-width: 768px) 12vw, 3rem"
                     />
                 </div>
 
                 {/* 아이템명 + 스타포스 + 등급 */}
-                <div>
-                    <h3 className="font-bold text-sm flex items-center gap-2">
+                <div className="space-y-1">
+                    <h3 className="font-bold text-sm sm:text-base flex items-center gap-2">
                         {item.item_name}
                         {item.starforce && (
-                            <span className="text-yellow-400 text-xs">★{item.starforce}</span>
+                            <span className="text-yellow-400 text-[0.7rem] sm:text-xs">★{item.starforce}</span>
                         )}
                     </h3>
                     {item.potential_option_grade && (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-[0.7rem] sm:text-xs text-muted-foreground">
                             {t("character.item.equipment.potential.gradeLabel", {
                                 grade: item.potential_option_grade,
                             })}
@@ -75,7 +86,7 @@ const ItemEquipDetail = ({ item }: ItemEquipDetailProps) => {
             </div>
 
             {/* 주요 옵션 */}
-            <div className="text-sm space-y-1 mb-4">
+            <div className="text-xs sm:text-sm space-y-1.5 mb-3 sm:mb-4">
                 {mainOptions.map(([label, statKey, totalValue]) => (
                     <RenderOptionRow
                         key={label}
@@ -91,11 +102,11 @@ const ItemEquipDetail = ({ item }: ItemEquipDetailProps) => {
                 ))}
             </div>
 
-            <div className="space-y-2 text-xs">
+            <div className="space-y-2 text-[0.7rem] sm:text-xs">
                 {/* 잠재 옵션 */}
                 {item.potential_option_grade && (
                     <div className={getGradeColor(item?.potential_option_grade)}>
-                        <p className="mb-1 text-card-foreground">
+                        <p className="mb-1 text-card-foreground text-xs">
                             {t("character.item.equipment.potential.label")}
                         </p>
                         {item.potential_option_1 && <p>{item.potential_option_1}</p>}
@@ -106,7 +117,7 @@ const ItemEquipDetail = ({ item }: ItemEquipDetailProps) => {
                 {/* 에디셔널 잠재 */}
                 {item.additional_potential_option_grade && (
                     <div className={getGradeColor(item.additional_potential_option_grade)}>
-                        <p className="mb-1 text-card-foreground">
+                        <p className="mb-1 text-card-foreground text-xs">
                             {t("character.item.equipment.additionalPotential.label")}
                         </p>
                         {item.additional_potential_option_1 && <p>{item.additional_potential_option_1}</p>}

--- a/src/components/character/item/ItemEquipments.tsx
+++ b/src/components/character/item/ItemEquipments.tsx
@@ -3,7 +3,7 @@ import { Fragment, type CSSProperties } from "react";
 import ItemEquipDetail from "@/components/character/item/ItemEquipDetail";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { IItemEquipment } from "@/interface/character/ICharacter";
 import { useTranslations } from "@/providers/LanguageProvider";
@@ -126,6 +126,9 @@ const ItemEquipments = ({ items = [], loading }: IEquipmentGrid) => {
                                             side="bottom"
                                             className="sm:hidden border-none p-4 pb-6 max-h-[85vh] overflow-y-auto"
                                         >
+                                            <SheetTitle className="sr-only">
+                                                {equip.item_name}
+                                            </SheetTitle>
                                             <div className="flex w-full justify-center">
                                                 <ItemEquipDetail item={equip}/>
                                             </div>

--- a/src/components/character/item/ItemEquipments.tsx
+++ b/src/components/character/item/ItemEquipments.tsx
@@ -1,7 +1,9 @@
 import Image from "next/image";
+import { Fragment, type CSSProperties } from "react";
 import ItemEquipDetail from "@/components/character/item/ItemEquipDetail";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { IItemEquipment } from "@/interface/character/ICharacter";
 import { useTranslations } from "@/providers/LanguageProvider";
@@ -46,53 +48,104 @@ const slotPosition: Record<string, { col: number; row: number }> = {
 
 const ItemEquipments = ({ items = [], loading }: IEquipmentGrid) => {
     const t = useTranslations();
+    const slotStyle: CSSProperties = {
+        width: "clamp(2rem, 7vw, 3.5rem)",
+        height: "clamp(2rem, 7vw, 3.5rem)",
+        padding: "clamp(0.2rem, 0.8vw, 0.45rem)",
+    };
+    const skeletonStyle: CSSProperties = {
+        width: "clamp(1.5rem, 4.5vw, 2.5rem)",
+        height: "clamp(1.5rem, 4.5vw, 2.5rem)",
+    };
 
     return (
         <Card className="w-full">
             <CardHeader>
                 <CardTitle>{t("character.item.equipment.title")}</CardTitle>
             </CardHeader>
-            <CardContent className="flex w-full justify-center px-2 sm:px-6">
-                <div className="grid grid-cols-5 grid-rows-6 gap-1.5 sm:gap-2 p-2 sm:p-4 bg-muted rounded-lg w-fit">
+            <CardContent className="flex w-full justify-center px-2 sm:px-4">
+                <div className="grid grid-cols-5 grid-rows-6 gap-1.5 sm:gap-2 p-2 sm:p-3 md:p-4 bg-muted rounded-lg w-fit">
                     {Object.entries(slotPosition).map(([slot, pos]) => {
                         const equip = items.find((item) => item.item_equipment_slot === slot);
 
                         if (equip && !loading) {
                             return (
-                                <Popover key={slot}>
-                                    <PopoverTrigger asChild>
-                                        <div
-                                            className="w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 p-2 border rounded-md flex items-center justify-center bg-card cursor-pointer hover:shadow-md"
-                                            style={{ gridColumnStart: pos.col, gridRowStart: pos.row }}
+                                <Fragment key={slot}>
+                                    <Popover>
+                                        <PopoverTrigger asChild>
+                                            <div
+                                                className="hidden sm:flex border rounded-md items-center justify-center bg-card cursor-pointer transition-transform duration-150 hover:shadow-md hover:scale-[1.02]"
+                                                style={{
+                                                    ...slotStyle,
+                                                    gridColumnStart: pos.col,
+                                                    gridRowStart: pos.row,
+                                                }}
+                                            >
+                                                <Image
+                                                    src={equip.item_icon}
+                                                    alt={equip.item_name}
+                                                    width={48}
+                                                    height={48}
+                                                    sizes="(max-width: 768px) 10vw, 3.5rem"
+                                                    className="h-full w-full object-contain"
+                                                    priority
+                                                />
+                                            </div>
+                                        </PopoverTrigger>
+                                        <PopoverContent
+                                            side="right"
+                                            align="start"
+                                            sideOffset={8}
+                                            className="hidden border-none bg-transparent p-0 shadow-none sm:block"
                                         >
-                                            <Image
-                                                src={equip.item_icon}
-                                                alt={equip.item_name}
-                                                width={48}
-                                                height={48}
-                                                className="w-8 h-auto sm:w-10 md:w-12"
-                                                priority
-                                            />
-                                        </div>
-                                    </PopoverTrigger>
-                                    <PopoverContent
-                                        side="right"
-                                        align="start"
-                                        className="p-0 bg-transparent border-none shadow-none"
-                                    >
-                                        <ItemEquipDetail item={equip}/>
-                                    </PopoverContent>
-                                </Popover>
+                                            <ItemEquipDetail item={equip}/>
+                                        </PopoverContent>
+                                    </Popover>
+                                    <Sheet>
+                                        <SheetTrigger asChild>
+                                            <div
+                                                className="flex sm:hidden border rounded-md items-center justify-center bg-card cursor-pointer transition-transform duration-150 hover:shadow-md hover:scale-[1.02]"
+                                                style={{
+                                                    ...slotStyle,
+                                                    gridColumnStart: pos.col,
+                                                    gridRowStart: pos.row,
+                                                }}
+                                            >
+                                                <Image
+                                                    src={equip.item_icon}
+                                                    alt={equip.item_name}
+                                                    width={48}
+                                                    height={48}
+                                                    sizes="(max-width: 768px) 10vw, 3.5rem"
+                                                    className="h-full w-full object-contain"
+                                                    priority
+                                                />
+                                            </div>
+                                        </SheetTrigger>
+                                        <SheetContent
+                                            side="bottom"
+                                            className="sm:hidden border-none p-4 pb-6 max-h-[85vh] overflow-y-auto"
+                                        >
+                                            <div className="flex w-full justify-center">
+                                                <ItemEquipDetail item={equip}/>
+                                            </div>
+                                        </SheetContent>
+                                    </Sheet>
+                                </Fragment>
                             );
                         }
 
                         return (
                             <div
                                 key={slot}
-                                className="w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 p-2 border rounded-md flex items-center justify-center bg-card"
-                                style={{ gridColumnStart: pos.col, gridRowStart: pos.row }}
+                                className="border rounded-md flex items-center justify-center bg-card"
+                                style={{
+                                    ...slotStyle,
+                                    gridColumnStart: pos.col,
+                                    gridRowStart: pos.row,
+                                }}
                             >
-                                <Skeleton className="w-6 h-6 sm:w-8 sm:h-8 md:w-10 md:h-10"/>
+                                <Skeleton className="h-full w-full" style={skeletonStyle}/>
                             </div>
                         );
                     })}

--- a/src/components/character/item/renderOptionRow.tsx
+++ b/src/components/character/item/renderOptionRow.tsx
@@ -25,15 +25,15 @@ const RenderOptionRow = ({ label, statKey, totalValue, base, add, etc, exception
     ].filter(Boolean);
 
     return (
-        <div className="flex justify-between text-sm">
-            <span className="text-blue-300">{label}</span>
-            <span className="min-w-[140px] text-right flex justify-end items-center gap-3 leading-5">
+        <div className="flex justify-between items-start text-xs sm:text-sm gap-3">
+            <span className="text-blue-300 leading-5 sm:leading-6">{label}</span>
+            <span className="min-w-[6.25rem] sm:min-w-[8.75rem] text-right flex justify-end items-center gap-2 sm:gap-3 leading-5 sm:leading-6">
                 {parts.length > 0 && (
-                    <span className="text-yellow-400 text-xs leading-5">
+                    <span className="text-yellow-400 text-[0.65rem] sm:text-xs leading-5 sm:leading-6">
                         ({parts.join(" ")})
                     </span>
                 )}
-                <span className="leading-5">+{totalValue}</span>
+                <span className="leading-5 sm:leading-6 text-xs sm:text-sm">+{totalValue}</span>
             </span>
         </div>
     );


### PR DESCRIPTION
## Summary
- scale equipment slot buttons based on viewport size so the grid adapts to narrow layouts
- update popover detail panels and typography to shrink gracefully on small screens
- swap equipment detail interactions to a bottom drawer on small screens for better usability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cce69628c88324b34168e828385f11