### PR TITLE
Fix cube page TypeScript issues

### DIFF
--- a/src/app/(main)/cube/page.tsx
+++ b/src/app/(main)/cube/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useCallback, useMemo, useState } from "react";
+import { type FormEvent, type ReactElement, useCallback, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
@@ -152,7 +152,7 @@ const CubePage = () => {
 
     const flagBadges = useCallback(
         (entry: CubeHistoryEntry) => {
-            const badges: JSX.Element[] = [];
+            const badges: ReactElement[] = [];
 
             if (isActiveFlag(entry.miracle_time_flag)) {
                 badges.push(

--- a/src/components/character/detail/Propensity.tsx
+++ b/src/components/character/detail/Propensity.tsx
@@ -2,6 +2,7 @@ import { PolarAngleAxis, PolarGrid, Radar, RadarChart, ResponsiveContainer, Tool
 import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import type { TranslationKey } from '@/constants/i18n/translations';
 import { ICharacterPropensity } from '@/interface/character/ICharacter';
 import { useTranslations } from '@/providers/LanguageProvider';
 
@@ -9,6 +10,23 @@ interface PropensityProps {
     propensity?: ICharacterPropensity | null;
     loading?: boolean;
 }
+
+type PropensityKey =
+    | 'charisma'
+    | 'empathy'
+    | 'insight'
+    | 'willpower'
+    | 'diligence'
+    | 'charm';
+
+const PROPENSITY_LABELS = {
+    charisma: 'character.detail.sections.propensity.labels.charisma',
+    empathy: 'character.detail.sections.propensity.labels.empathy',
+    insight: 'character.detail.sections.propensity.labels.insight',
+    willpower: 'character.detail.sections.propensity.labels.willpower',
+    diligence: 'character.detail.sections.propensity.labels.diligence',
+    charm: 'character.detail.sections.propensity.labels.charm',
+} satisfies Record<PropensityKey, TranslationKey>;
 
 // Tooltip props type 안전하게 정의
 interface CustomTooltipProps {
@@ -37,15 +55,17 @@ export const Propensity = ({ propensity, loading }: PropensityProps) => {
         );
     }
 
-    const data = [
-        { key: 'charisma', value: propensity.charisma_level },
-        { key: 'empathy', value: propensity.sensibility_level },
-        { key: 'insight', value: propensity.insight_level },
-        { key: 'willpower', value: propensity.willingness_level },
-        { key: 'diligence', value: propensity.handicraft_level },
-        { key: 'charm', value: propensity.charm_level },
-    ].map((item) => ({
-        subject: t(`character.detail.sections.propensity.labels.${item.key}`),
+    const data = (
+        [
+            { key: 'charisma', value: propensity.charisma_level },
+            { key: 'empathy', value: propensity.sensibility_level },
+            { key: 'insight', value: propensity.insight_level },
+            { key: 'willpower', value: propensity.willingness_level },
+            { key: 'diligence', value: propensity.handicraft_level },
+            { key: 'charm', value: propensity.charm_level },
+        ] satisfies { key: PropensityKey; value: number }[]
+    ).map((item) => ({
+        subject: t(PROPENSITY_LABELS[item.key]),
         value: item.value,
     }));
 

--- a/src/interface/history/IHistory.ts
+++ b/src/interface/history/IHistory.ts
@@ -66,6 +66,7 @@ export interface PotentialHistoryData {
 export interface CubeHistoryEntry {
     id: string;
     character_name: string;
+    world_name?: string;
     date_create: string;
     cube_type: string;
     item_upgrade_result: string;


### PR DESCRIPTION
## Summary
- use ReactElement typing for cube flag badges
- expose the optional `world_name` attribute on cube history entries
- strongly type propensity translation labels to satisfy TranslationKey constraints

## Testing
- npm run build *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68cd30a9091c83248127702781eefaca