### PR TITLE
Tighten home layout presentation

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -145,49 +145,49 @@ const Home = () => {
     return (
         <ViewTransition enter="fade" exit="fade">
             <ScrollArea className="h-page">
-                <div className="mx-auto flex h-full w-full max-w-6xl flex-col gap-5 px-3 pb-5 pt-4 sm:px-4">
-                    <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-primary/10 via-background to-background p-5 shadow-sm sm:p-6">
-                        <div className="absolute -right-24 top-1/2 hidden h-52 w-52 -translate-y-1/2 rounded-full bg-primary/30 blur-3xl md:block" aria-hidden />
+                <div className="mx-auto flex h-full w-full max-w-7xl flex-col gap-4 px-4 pb-6 pt-5 sm:px-5 lg:px-6">
+                    <section className="relative overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-primary/10 via-background to-background p-4 shadow-sm sm:p-5">
+                        <div className="absolute -right-24 top-1/2 hidden h-48 w-48 -translate-y-1/2 rounded-full bg-primary/30 blur-3xl md:block" aria-hidden />
                         <div className="relative flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-                            <div className="space-y-2">
-                                <span className="inline-flex w-fit items-center rounded-full border border-border/60 bg-background/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+                            <div className="space-y-1.5">
+                                <span className="inline-flex w-fit items-center rounded-full border border-border/60 bg-background/70 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.32em] text-muted-foreground">
                                     {t('home.hero.badge')}
                                 </span>
-                                <h1 className="text-3xl font-semibold leading-tight text-foreground sm:text-[2.125rem]">
+                                <h1 className="text-2xl font-semibold leading-snug text-foreground sm:text-[2rem]">
                                     {t('home.hero.title')}
                                 </h1>
                                 <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
                                     {t('home.hero.description')}
                                 </p>
                             </div>
-                            <div className="grid w-full gap-3 sm:max-w-lg sm:grid-cols-2">
+                            <div className="grid w-full gap-2.5 sm:max-w-md sm:grid-cols-2 lg:max-w-lg">
                                 {stats.map(({ key, label, value, helper, Icon, showSkeleton }) => (
-                                    <div key={key} className="rounded-2xl border border-border/60 bg-background/70 p-4 shadow-sm">
+                                    <div key={key} className="rounded-2xl border border-border/60 bg-background/80 p-3 shadow-sm sm:p-4">
                                         <div className="flex items-center gap-3">
-                                            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+                                            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">
                                                 <Icon className="h-4 w-4" />
                                             </div>
                                             <div>
-                                                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                                <p className="text-[0.7rem] font-semibold uppercase tracking-wide text-muted-foreground">
                                                     {label}
                                                 </p>
-                                                <div className="text-xl font-semibold text-foreground">
+                                                <div className="text-lg font-semibold text-foreground sm:text-xl">
                                                     {showSkeleton ? <Skeleton className="h-6 w-12 rounded-md" /> : value}
                                                 </div>
                                             </div>
                                         </div>
-                                        <p className="mt-3 text-xs text-muted-foreground">{helper}</p>
+                                        <p className="mt-2 text-xs text-muted-foreground">{helper}</p>
                                     </div>
                                 ))}
                             </div>
                         </div>
                     </section>
 
-                    <div className="flex flex-1 min-h-0 flex-col gap-5 md:flex-row">
-                        <ScrollArea className="h-full max-h-[var(--height-page)] md:w-[320px] xl:w-[360px]">
-                            <section className="flex h-full flex-col overflow-hidden rounded-3xl border border-border/60 bg-background/80 shadow-sm backdrop-blur md:w-[320px] xl:w-[360px]">
-                                <div className="border-b border-border/60 px-5 py-4">
-                                    <h2 className="text-lg font-semibold text-foreground">{t('home.favorites.title')}</h2>
+                    <div className="flex min-h-0 flex-1 flex-col gap-4 md:flex-row">
+                        <ScrollArea className="h-full max-h-[var(--height-page)] md:w-[340px] xl:w-[380px]">
+                            <section className="flex h-full flex-col overflow-hidden rounded-2xl border border-border/60 bg-background/85 shadow-sm backdrop-blur">
+                                <div className="border-b border-border/60 px-4 py-3.5">
+                                    <h2 className="text-base font-semibold text-foreground">{t('home.favorites.title')}</h2>
                                     <p className="text-sm text-muted-foreground">{t('home.favorites.description')}</p>
                                 </div>
                                 <FavoriteList
@@ -201,20 +201,22 @@ const Home = () => {
                             </section>
                         </ScrollArea>
 
-                        <section className="hidden min-h-0 flex-1 overflow-hidden rounded-3xl border border-border/60 bg-background/80 shadow-sm backdrop-blur md:flex">
-                            <CharacterInfo ocid={selected} goToDetailPage={goToDetailPage} className="h-full" />
-                        </section>
+                        <CharacterInfo
+                            ocid={selected}
+                            goToDetailPage={goToDetailPage}
+                            className="hidden min-h-0 flex-1 md:flex"
+                        />
                     </div>
 
                     <Dialog open={open} onOpenChange={setOpen}>
                         <DialogContent className="top-1/2 left-1/2 h-auto max-h-[85vh] w-[min(90vw,26rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-3xl border border-border/60 bg-background/95 p-0 shadow-2xl backdrop-blur">
-                            <DialogTitle className="px-6 pt-6 text-base font-semibold">
+                            <DialogTitle className="px-5 pt-5 text-sm font-semibold">
                                 {t('home.dialog.title')}
                             </DialogTitle>
                             <CharacterInfo
                                 ocid={selected}
                                 goToDetailPage={goToDetailPage}
-                                className="max-h-[65vh]"
+                                className="max-h-[65vh] border-none bg-transparent shadow-none backdrop-blur-none"
                             />
                         </DialogContent>
                     </Dialog>

--- a/src/components/home/CharacterInfo.tsx
+++ b/src/components/home/CharacterInfo.tsx
@@ -71,103 +71,110 @@ const CharacterInfo = ({ ocid, goToDetailPage, className }: ICharacterInfoProps)
     }, [basic?.character_image]);
 
     return (
-        <ScrollArea className={cn("h-full", className)}>
-            <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-6 p-6">
-                {!ocid ? (
-                    <div className="flex flex-1 items-center justify-center">
-                        <div className="rounded-3xl border border-dashed border-border/60 bg-muted/20 px-8 py-12 text-center text-sm text-muted-foreground">
-                            {t('home.characterInfo.emptyState')}
+        <div
+            className={cn(
+                "flex h-full min-h-0 flex-col overflow-hidden rounded-3xl border border-border/60 bg-background/90 shadow-sm backdrop-blur",
+                className,
+            )}
+        >
+            <ScrollArea className="h-full">
+                <div className="flex h-full w-full flex-col gap-5 px-4 py-5 sm:px-5">
+                    {!ocid ? (
+                        <div className="flex flex-1 items-center justify-center py-12">
+                            <div className="rounded-3xl border border-dashed border-border/60 bg-muted/20 px-8 py-10 text-center text-sm text-muted-foreground">
+                                {t('home.characterInfo.emptyState')}
+                            </div>
                         </div>
-                    </div>
-                ) : (
-                    <div className="relative overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-primary/10 via-background to-background p-6 shadow-sm">
-                        <div className="absolute -right-24 top-1/2 hidden h-64 w-64 -translate-y-1/2 rounded-full bg-primary/30 blur-3xl xl:block" aria-hidden />
-                        <div className="relative flex flex-col gap-6 xl:flex-row">
-                            <section className="flex flex-col items-center gap-5 text-center xl:w-72 xl:items-start xl:text-left">
-                                <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-                                    {loading || !basic ? (
-                                        <>
-                                            <Skeleton className="h-6 w-6 rounded-full" />
-                                            <Skeleton className="h-4 w-24" />
-                                        </>
-                                    ) : (
-                                        <>
-                                            <WorldIcon name={basic.world_name} />
-                                            <span>{basic.world_name}</span>
-                                        </>
-                                    )}
-                                </div>
+                    ) : (
+                        <div className="relative overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-primary/10 via-background to-background px-5 py-5 shadow-sm">
+                            <div className="absolute -right-24 top-1/2 hidden h-64 w-64 -translate-y-1/2 rounded-full bg-primary/30 blur-3xl xl:block" aria-hidden />
+                            <div className="relative flex flex-col gap-6 xl:flex-row">
+                                <section className="flex flex-col items-center gap-5 text-center xl:w-72 xl:items-start xl:text-left">
+                                    <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                                        {loading || !basic ? (
+                                            <>
+                                                <Skeleton className="h-6 w-6 rounded-full" />
+                                                <Skeleton className="h-4 w-24" />
+                                            </>
+                                        ) : (
+                                            <>
+                                                <WorldIcon name={basic.world_name} />
+                                                <span>{basic.world_name}</span>
+                                            </>
+                                        )}
+                                    </div>
 
-                                <div className="relative aspect-square w-52 max-w-full overflow-hidden rounded-2xl border border-border/40 bg-background/70 p-6 shadow-inner">
-                                    {loading || !basic ? (
-                                        <Skeleton className="h-full w-full" />
-                                    ) : (
-                                        characterImageSrc && (
-                                            <div
-                                                className="flex h-full w-full items-center justify-center"
-                                                style={imageTransitionName ? { viewTransitionName: imageTransitionName } : undefined}
-                                            >
-                                                <Image
-                                                    src={characterImageSrc}
-                                                    alt={basic.character_name}
-                                                    className="h-full w-auto max-h-full object-contain"
-                                                    width={200}
-                                                    height={200}
-                                                    priority
-                                                />
-                                            </div>
-                                        )
-                                    )}
-                                </div>
+                                    <div className="relative aspect-square w-52 max-w-full overflow-hidden rounded-2xl border border-border/40 bg-background/70 p-5 shadow-inner">
+                                        {loading || !basic ? (
+                                            <Skeleton className="h-full w-full" />
+                                        ) : (
+                                            characterImageSrc && (
+                                                <div
+                                                    className="flex h-full w-full items-center justify-center"
+                                                    style={imageTransitionName ? { viewTransitionName: imageTransitionName } : undefined}
+                                                >
+                                                    <Image
+                                                        src={characterImageSrc}
+                                                        alt={basic.character_name}
+                                                        className="h-full w-auto max-h-full object-contain"
+                                                        width={200}
+                                                        height={200}
+                                                        priority
+                                                    />
+                                                </div>
+                                            )
+                                        )}
+                                    </div>
 
-                                <div className="space-y-1">
-                                    {loading || !basic ? (
-                                        <Skeleton className="h-8 w-40" />
-                                    ) : (
-                                        <h2 className="text-3xl font-semibold tracking-tight text-foreground">
-                                            {basic.character_name}
-                                        </h2>
-                                    )}
-                                    {loading || !basic ? (
-                                        <Skeleton className="h-5 w-32" />
-                                    ) : (
-                                        <p className="text-sm text-muted-foreground">
-                                            {basic.character_class}
-                                        </p>
-                                    )}
-                                </div>
+                                    <div className="space-y-1">
+                                        {loading || !basic ? (
+                                            <Skeleton className="h-8 w-40" />
+                                        ) : (
+                                            <h2 className="text-3xl font-semibold tracking-tight text-foreground">
+                                                {basic.character_name}
+                                            </h2>
+                                        )}
+                                        {loading || !basic ? (
+                                            <Skeleton className="h-5 w-32" />
+                                        ) : (
+                                            <p className="text-sm text-muted-foreground">
+                                                {basic.character_class}
+                                            </p>
+                                        )}
+                                    </div>
 
-                                <div className="flex items-center justify-center gap-2 xl:justify-start">
-                                    {loading || !basic ? (
-                                        <Skeleton className="h-8 w-24" />
-                                    ) : (
-                                        <span className="rounded-full bg-primary/10 px-4 py-1 text-sm font-semibold text-primary">
-                                            {t('home.stats.level', { level: basic.character_level })}
-                                        </span>
-                                    )}
-                                </div>
+                                    <div className="flex items-center justify-center gap-2 xl:justify-start">
+                                        {loading || !basic ? (
+                                            <Skeleton className="h-8 w-24" />
+                                        ) : (
+                                            <span className="rounded-full bg-primary/10 px-4 py-1 text-sm font-semibold text-primary">
+                                                {t('home.stats.level', { level: basic.character_level })}
+                                            </span>
+                                        )}
+                                    </div>
 
-                                <div className="flex w-full justify-center xl:justify-start">
-                                    {loading || !basic ? (
-                                        <Skeleton className="h-10 w-28" />
-                                    ) : (
-                                        <Button onClick={goToDetailPage} className="rounded-full px-6">
-                                            {t('home.characterInfo.detailButton')}
-                                        </Button>
-                                    )}
-                                </div>
-                            </section>
+                                    <div className="flex w-full justify-center xl:justify-start">
+                                        {loading || !basic ? (
+                                            <Skeleton className="h-10 w-28" />
+                                        ) : (
+                                            <Button onClick={goToDetailPage} className="rounded-full px-6">
+                                                {t('home.characterInfo.detailButton')}
+                                            </Button>
+                                        )}
+                                    </div>
+                                </section>
 
-                            <div className="flex flex-1 items-stretch">
-                                <div className="w-full max-w-xl xl:ml-auto">
-                                    <ItemEquipments items={items} loading={loading || !basic} />
+                                <div className="flex flex-1 items-stretch">
+                                    <div className="w-full max-w-2xl xl:ml-auto xl:max-w-3xl">
+                                        <ItemEquipments items={items} loading={loading || !basic} />
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                )}
-            </div>
-        </ScrollArea>
+                    )}
+                </div>
+            </ScrollArea>
+        </div>
     );
 };
 

--- a/src/components/home/FavoriteList.tsx
+++ b/src/components/home/FavoriteList.tsx
@@ -25,7 +25,7 @@ const FavoriteList = ({
 }: IFavoriteListProps) => {
     return (
         <ScrollArea className={cn("h-full", className)}>
-            <div className="space-y-4 px-5 py-5">
+            <div className="space-y-4 px-4 py-4 sm:px-5">
                 {loading ? (
                     Array.from({ length: 3 }).map((_, i) => <CharacterCardSkeleton key={i} />)
                 ) : favorites.length > 0 ? (


### PR DESCRIPTION
## Summary
- expand the /home layout to `max-w-7xl`, tighten the hero spacing, and widen the favorites column so the lower content reads larger
- let `CharacterInfo` render its own bordered card with reduced padding and a wider equipment area, eliminating the extra wrapper section
- adjust favorite list padding and the mobile dialog styling to stay consistent with the denser layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd52e00790832489c7157128b8df2c