### PR TITLE
Implement lazy image loading for character list

### DIFF
--- a/src/app/(main)/character_list/page.tsx
+++ b/src/app/(main)/character_list/page.tsx
@@ -22,12 +22,17 @@ const ALL_WORLDS_VALUE = "all";
 const CharacterList = () => {
     const t = useTranslations();
     const setApiKey = userStore((s) => s.setApiKey);
-    const { characters, loading, fetchCharacters } = characterListStore();
+    const { characters, loading, fetchCharacters, loadCharacterImage } = characterListStore();
     const [displayCharacters, setDisplayCharacters] = useState<ICharacterSummary[]>([]);
     const [worldFilter, setWorldFilter] = useState(ALL_WORLDS_VALUE);
     const [searchKeyword, setSearchKeyword] = useState("");
     const { favorites, setFavorites, addFavorite: addFavoriteOcid, removeFavorite: removeFavoriteOcid } = favoriteStore();
     const [userId, setUserId] = useState<string | null>(null);
+    const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
+
+    const handleScrollContainerRef = useCallback((node: HTMLDivElement | null) => {
+        setScrollContainer(node);
+    }, []);
 
     useEffect(() => {
         const load = async () => {
@@ -228,7 +233,7 @@ const CharacterList = () => {
                                     </div>
                                 </div>
                             ) : (
-                                <div className="h-full overflow-y-auto px-2 pb-6">
+                                <div ref={handleScrollContainerRef} className="h-full overflow-y-auto px-2 pb-6">
                                     <div className="grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
                                         {displayCharacters.map((character) => (
                                             <CharacterCell
@@ -236,6 +241,8 @@ const CharacterList = () => {
                                                 character={character}
                                                 favorites={favorites}
                                                 toggleFavorite={toggleFavorite}
+                                                loadCharacterImage={loadCharacterImage}
+                                                scrollContainer={scrollContainer}
                                             />
                                         ))}
                                     </div>

--- a/src/components/character/CharacterCell.tsx
+++ b/src/components/character/CharacterCell.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { useRouter } from "next/navigation";
-import { memo } from "react";
+import { memo, useEffect, useRef } from "react";
 import CharacterCard from "@/components/character/CharacterCard";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
 
@@ -7,13 +9,67 @@ interface ICharacterCellProps {
     character: ICharacterSummary;
     favorites: string[];
     toggleFavorite: (ocid: string) => void;
+    loadCharacterImage: (ocid: string) => Promise<void>;
+    scrollContainer: HTMLElement | null;
 }
 
-const CharacterCell = memo(({ character, favorites, toggleFavorite }: ICharacterCellProps) => {
+const CharacterCell = memo(({
+    character,
+    favorites,
+    toggleFavorite,
+    loadCharacterImage,
+    scrollContainer,
+}: ICharacterCellProps) => {
     const router = useRouter();
+    const cellRef = useRef<HTMLDivElement | null>(null);
+    const requestedImageRef = useRef(false);
+
+    useEffect(() => {
+        requestedImageRef.current = Boolean(character.image);
+    }, [character.ocid, character.image]);
+
+    useEffect(() => {
+        if (character.image || requestedImageRef.current) {
+            return;
+        }
+
+        if (typeof window === "undefined" || typeof IntersectionObserver === "undefined") {
+            requestedImageRef.current = true;
+            void loadCharacterImage(character.ocid);
+            return;
+        }
+
+        const element = cellRef.current;
+        if (!element) {
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        requestedImageRef.current = true;
+                        observer.disconnect();
+                        void loadCharacterImage(character.ocid);
+                    }
+                });
+            },
+            {
+                root: scrollContainer ?? null,
+                rootMargin: "0px 0px 300px 0px",
+                threshold: 0,
+            },
+        );
+
+        observer.observe(element);
+
+        return () => {
+            observer.disconnect();
+        };
+    }, [character.image, character.ocid, loadCharacterImage, scrollContainer]);
 
     return (
-        <div className="p-2 w-full">
+        <div ref={cellRef} className="p-2 w-full">
             <CharacterCard
                 character={character}
                 isFavorite={favorites.includes(character.ocid)}


### PR DESCRIPTION
## Summary
- stop eagerly downloading character images when building the list and preserve any previously cached thumbnails
- add a loadCharacterImage helper that deduplicates concurrent fetches and updates the store on demand
- lazily request images from the character list grid using an IntersectionObserver tied to the scroll container

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce85248ff483249b66e003a9d0cb01