### PR TITLE
Aggregate boss difficulties into segmented controls

### DIFF
--- a/src/constants/i18n/en.ts
+++ b/src/constants/i18n/en.ts
@@ -97,6 +97,13 @@ export const en = {
                 done: "Cleared",
                 todo: "Pending",
             },
+            difficulties: {
+                easy: "Easy",
+                normal: "Normal",
+                hard: "Hard",
+                chaos: "Chaos",
+                extreme: "Extreme",
+            },
             frequency: {
                 daily: "Daily",
                 weekly: "Weekly",

--- a/src/constants/i18n/ko.ts
+++ b/src/constants/i18n/ko.ts
@@ -96,6 +96,13 @@ export const ko = {
                 done: "완료",
                 todo: "예정",
             },
+            difficulties: {
+                easy: "이지",
+                normal: "노멀",
+                hard: "하드",
+                chaos: "카오스",
+                extreme: "익스트림",
+            },
             frequency: {
                 daily: "데일리",
                 weekly: "주간",

--- a/src/constants/todoList.ts
+++ b/src/constants/todoList.ts
@@ -80,7 +80,8 @@ export const BOSS_PRICE_BY_ID = BOSS_PRICE_TABLE.reduce<Record<string, BossPrice
 
 export type TodoListBoss = {
     id: string;
-    name: string;
+    label: string;
+    bossName: string;
     difficulty: BossPriceEntry["difficulty"];
     reward: number; // mesos
     frequency: BossFrequency;
@@ -98,7 +99,8 @@ const createBoss = (priceId: BossPriceEntry["id"]): TodoListBoss => {
     const entry = BOSS_PRICE_BY_ID[priceId];
     return {
         id: entry.id,
-        name: entry.label,
+        label: entry.label,
+        bossName: entry.boss,
         difficulty: entry.difficulty,
         reward: entry.price,
         frequency: entry.frequency,


### PR DESCRIPTION
## Summary
- group checklist bosses by their base name so multiple difficulties share a single row
- replace the per-difficulty row toggle with segmented buttons that only allow one difficulty to be cleared at a time
- add localized difficulty labels for the new difficulty buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cc6215d483249b6bc1120d2f6879