### PR TITLE
Fix weekly boss typings and translation keys

### DIFF
--- a/src/components/todo-list/WeeklyBossPanel.tsx
+++ b/src/components/todo-list/WeeklyBossPanel.tsx
@@ -9,6 +9,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { TranslationKey } from "@/constants/i18n/translations";
 import { BossFrequency, TODO_LIST_BOSS_GROUPS, TODO_LIST_BOSS_MAP, TodoListBoss, TodoListBossGroup, WEEKLY_CHARACTER_CLEAR_LIMIT, WEEKLY_WORLD_CLEAR_LIMIT, } from "@/constants/todoList";
 import { MonthlyBossState, TODO_LIST_UNASSIGNED_CHARACTER_KEY, TODO_LIST_UNASSIGNED_WORLD_KEY, WeeklyBossCharacterState, WeeklyBossState, } from "@/fetchs/todoList.fetch";
 import { ICharacterSummary } from "@/interface/character/ICharacterSummary";
@@ -57,12 +58,12 @@ const countWeeklyClears = (character: WeeklyBossCharacterState) =>
         return acc;
     }, 0);
 
-const DIFFICULTY_LABEL_KEY_MAP: Record<TodoListBoss["difficulty"], string> = {
-    Easy: "easy",
-    Normal: "normal",
-    Hard: "hard",
-    Chaos: "chaos",
-    Extreme: "extreme",
+const DIFFICULTY_LABEL_KEY_MAP: Record<TodoListBoss["difficulty"], TranslationKey> = {
+    Easy: "todoList.bosses.difficulties.easy",
+    Normal: "todoList.bosses.difficulties.normal",
+    Hard: "todoList.bosses.difficulties.hard",
+    Chaos: "todoList.bosses.difficulties.chaos",
+    Extreme: "todoList.bosses.difficulties.extreme",
 };
 
 const WORLD_STORAGE_KEY = "todoList:selectedWorld";
@@ -424,10 +425,7 @@ const WeeklyBossPanel = ({
                                                 isMonthly
                                                     ? anyCleared && !cleared
                                                     : !selectedCharacter || (anyCleared && !cleared);
-                                            const difficultyKey = DIFFICULTY_LABEL_KEY_MAP[entry.difficulty];
-                                            const difficultyLabel = t(
-                                                `todoList.bosses.difficulties.${difficultyKey}`,
-                                            );
+                                            const difficultyLabel = t(DIFFICULTY_LABEL_KEY_MAP[entry.difficulty]);
 
                                             const otherCleared = boss.bosses.some(
                                                 (other) =>

--- a/src/fetchs/todoList.fetch.ts
+++ b/src/fetchs/todoList.fetch.ts
@@ -19,7 +19,7 @@ export const TODO_LIST_UNASSIGNED_CHARACTER_KEY = "__unassigned__";
 export type BossClearState = { clearedAt: string | null };
 
 export type WeeklyBossCharacterState = Record<string, BossClearState>;
-export type WeeklyBossWorldState = Record<string, WeeklyBossCharacterState>;
+export type WeeklyBossWorldState = Record<string, Record<string, WeeklyBossCharacterState>>;
 
 export type WeeklyBossState = {
     version: typeof TODO_LIST_WEEKLY_STATE_VERSION;
@@ -152,16 +152,15 @@ const sanitizeWeeklyState = (value: unknown): WeeklyBossState => {
                     return worldAcc;
                 }
 
-                const sanitizedWorld = Object.entries(worldValue as Record<string, unknown>).reduce<WeeklyBossCharacterState>(
-                    (characterAcc, [characterId, bossValue]) => {
-                        const bosses = sanitizeBossEntries(bossValue);
-                        if (Object.keys(bosses).length > 0) {
-                            characterAcc[characterId] = bosses;
-                        }
-                        return characterAcc;
-                    },
-                    {},
-                );
+                const sanitizedWorld = Object.entries(worldValue as Record<string, unknown>).reduce<
+                    Record<string, WeeklyBossCharacterState>
+                >((characterAcc, [characterId, bossValue]) => {
+                    const bosses = sanitizeBossEntries(bossValue);
+                    if (Object.keys(bosses).length > 0) {
+                        characterAcc[characterId] = bosses;
+                    }
+                    return characterAcc;
+                }, {});
 
                 if (Object.keys(sanitizedWorld).length > 0) {
                     worldAcc[worldKey] = sanitizedWorld;


### PR DESCRIPTION
## Summary
- fix weekly boss world state typings to correctly nest characters under each world
- tighten weekly state sanitisation to build nested character maps safely
- map boss difficulty labels to explicit translation keys to satisfy the translator type

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5e8e2ff108324980fdcf065c93a57