### PR TITLE
Adjust todo list hero scroll behavior

### DIFF
--- a/src/app/(main)/todo_list/layout.tsx
+++ b/src/app/(main)/todo_list/layout.tsx
@@ -25,53 +25,55 @@ const TodoListLayout = ({ children }: { children: React.ReactNode }) => {
     const t = useTranslations();
 
     return (
-        <div className="flex h-full w-full flex-col gap-6 overflow-hidden">
-            <section className="relative overflow-hidden rounded-3xl border bg-gradient-to-br from-primary/10 via-background to-background p-6 shadow-xl">
-                <div className="pointer-events-none absolute -right-20 -top-24 h-64 w-64 rounded-full bg-primary/20 blur-3xl" />
-                <div className="pointer-events-none absolute -bottom-16 -left-24 h-72 w-72 rounded-full bg-primary/10 blur-3xl" />
-                <div className="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-                    <div className="space-y-2">
-                        <Badge variant="secondary" className="bg-primary/20 text-primary">
-                            {t("todoList.hero.badge")}
-                        </Badge>
-                        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-                            {t("todoList.hero.title")}
-                        </h1>
-                        <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
-                            {t("todoList.hero.description")}
-                        </p>
-                    </div>
-                    <div className="rounded-2xl border border-primary/30 bg-background/90 px-4 py-3 text-sm text-primary shadow-sm">
-                        {t("todoList.hero.resetInfo")}
-                    </div>
-                </div>
-            </section>
+        <div className="flex h-full w-full flex-col">
+            <div className="flex-1 overflow-auto">
+                <div className="flex min-h-full flex-col gap-6 pb-6">
+                    <section className="relative overflow-hidden rounded-3xl border bg-gradient-to-br from-primary/10 via-background to-background p-6 shadow-xl">
+                        <div className="pointer-events-none absolute -right-20 -top-24 h-64 w-64 rounded-full bg-primary/20 blur-3xl" />
+                        <div className="pointer-events-none absolute -bottom-16 -left-24 h-72 w-72 rounded-full bg-primary/10 blur-3xl" />
+                        <div className="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                            <div className="space-y-2">
+                                <Badge variant="secondary" className="bg-primary/20 text-primary">
+                                    {t("todoList.hero.badge")}
+                                </Badge>
+                                <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+                                    {t("todoList.hero.title")}
+                                </h1>
+                                <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+                                    {t("todoList.hero.description")}
+                                </p>
+                            </div>
+                            <div className="rounded-2xl border border-primary/30 bg-background/90 px-4 py-3 text-sm text-primary shadow-sm">
+                                {t("todoList.hero.resetInfo")}
+                            </div>
+                        </div>
+                    </section>
 
-            <nav className="flex flex-wrap gap-3">
-                {NAV_ITEMS.map((item) => {
-                    const Icon = item.icon;
-                    const active = pathname === item.href;
-                    return (
-                        <Link
-                            key={item.href}
-                            href={item.href}
-                            className={cn(
-                                "flex items-center gap-2 rounded-2xl border px-4 py-2 text-sm font-semibold transition",
-                                active
-                                    ? "border-primary/60 bg-primary text-primary-foreground shadow"
-                                    : "border-border bg-background hover:border-primary/40 hover:text-primary",
-                            )}
-                        >
-                            <Icon className="h-4 w-4" />
-                            {t(item.labelKey)}
-                        </Link>
-                    );
-                })}
-            </nav>
+                    <nav className="sticky top-0 z-20 flex flex-wrap gap-3 rounded-2xl border border-border/80 bg-background/95 p-3 backdrop-blur supports-[backdrop-filter]:bg-background/75">
+                        {NAV_ITEMS.map((item) => {
+                            const Icon = item.icon;
+                            const active = pathname === item.href;
+                            return (
+                                <Link
+                                    key={item.href}
+                                    href={item.href}
+                                    className={cn(
+                                        "flex items-center gap-2 rounded-2xl border px-4 py-2 text-sm font-semibold transition",
+                                        active
+                                            ? "border-primary/60 bg-primary text-primary-foreground shadow"
+                                            : "border-border bg-background hover:border-primary/40 hover:text-primary",
+                                    )}
+                                >
+                                    <Icon className="h-4 w-4" />
+                                    {t(item.labelKey)}
+                                </Link>
+                            );
+                        })}
+                    </nav>
 
-            <div className="min-h-0 flex-1 overflow-auto pb-6">
-                <div className="flex h-full flex-col gap-6">
-                    {children}
+                    <div className="flex flex-1 flex-col gap-6">
+                        {children}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- allow the todo list hero section to participate in the scroll container so it disappears as you scroll
- keep the navigation links visible by making the nav sticky with its own backdrop styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5eb3169288324ad23f6d30e5284dc