### PR TITLE
Fix monthly summary translation formatting

### DIFF
--- a/src/app/(main)/todo_list/dashboard/page.tsx
+++ b/src/app/(main)/todo_list/dashboard/page.tsx
@@ -116,6 +116,14 @@ const DashboardPage = () => {
         }, 0);
     }, [monthlyHistory]);
 
+    const monthlyClearsText = useMemo(() => {
+        if (language === "ko") {
+            return monthlyClears === 1 ? "한 번" : `${monthlyClears}번`;
+        }
+
+        return monthlyClears === 1 ? "once" : `${monthlyClears} times`;
+    }, [language, monthlyClears]);
+
     const weeklyChartData = useMemo(() => {
         return weeklyHistory.map((entry) => {
             const summary = summarizeWeeklyState(entry.state);
@@ -370,7 +378,7 @@ const DashboardPage = () => {
                         <div className="rounded-xl border bg-background/60 p-4 text-sm text-muted-foreground">
                             <p>
                                 {t("todoList.dashboard.monthly.summary", {
-                                    value: monthlyClears,
+                                    valueText: monthlyClearsText,
                                     total: TODO_LIST_MONTHLY_BOSS_IDS.length,
                                 })}
                             </p>

--- a/src/constants/i18n/en.ts
+++ b/src/constants/i18n/en.ts
@@ -221,7 +221,7 @@ export const en = {
                 barLabel: "Monthly boss clears",
                 tooltipLabel: "Monthly clears",
                 tooltipValue: "Cleared {value} of {total}",
-                summary: "Monthly bosses were cleared {value, plural, one {once} other {# times}} in total. ({total} available)",
+                summary: "Monthly bosses were cleared {valueText} in total. ({total} available)",
             },
         },
     },

--- a/src/constants/i18n/ko.ts
+++ b/src/constants/i18n/ko.ts
@@ -220,7 +220,7 @@ export const ko = {
                 barLabel: "월간 보스 클리어 수",
                 tooltipLabel: "월간 클리어",
                 tooltipValue: "{total}개 중 {value}개 완료",
-                summary: "최근 기록에서 월간 보스를 총 {value, plural, one {한 번} other {#번}} 완료했어요. (현재 {total}종)",
+                summary: "최근 기록에서 월간 보스를 총 {valueText} 완료했어요. (현재 {total}종)",
             },
         },
     },


### PR DESCRIPTION
## Summary
- update monthly summary translations to accept pre-formatted clear count text
- compute language-aware clear count text in the dashboard component so single clears read naturally

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d60ff182288324913161b026faafec