### PR TITLE
Implement six-month todo list retention cleanup

### DIFF
--- a/sql/todo_list_retention.sql
+++ b/sql/todo_list_retention.sql
@@ -1,0 +1,35 @@
+-- Set up automated cleanup for todo list data older than six months.
+-- Run this script inside your Supabase project's SQL editor.
+
+create extension if not exists pg_cron;
+
+create or replace function public.cleanup_expired_todo_list_entries(months integer default 6)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+    delete from public.todo_list_entries as entries
+    where entries.category in ('weekly_boss', 'monthly_boss', 'memo', 'calendar')
+      and coalesce(
+            entries.updated_at,
+            to_timestamp(nullif(entries.period_key, ''), 'YYYY-MM-DD')
+          ) < now() - make_interval(months => months);
+end;
+$$;
+
+comment on function public.cleanup_expired_todo_list_entries(integer)
+    is 'Deletes boss, calendar, and memo rows whose last update (or period key) is older than the configured number of months.';
+
+-- Replace any existing scheduled job with the same name to avoid duplicates.
+select cron.unschedule(jobid)
+from cron.job
+where jobname = 'todo_list_retention_cleanup';
+
+-- Schedule the cleanup to run daily at 04:00 KST (19:00 UTC).
+select cron.schedule(
+    'todo_list_retention_cleanup',
+    '0 19 * * *',
+    $$select public.cleanup_expired_todo_list_entries();$$
+);

--- a/src/fetchs/todoList.fetch.ts
+++ b/src/fetchs/todoList.fetch.ts
@@ -4,6 +4,8 @@ import { buildCalendarMatrix, formatKstDateKey, formatKstMonthKey, getMonthlyRes
 
 export const TODO_LIST_WEEKLY_STATE_VERSION = 2;
 
+export const TODO_LIST_RETENTION_MONTHS = 6;
+
 export const TODO_LIST_UNASSIGNED_WORLD_KEY = "__unassigned__";
 export const TODO_LIST_UNASSIGNED_CHARACTER_KEY = "__unassigned__";
 
@@ -81,8 +83,9 @@ const requireUserId = async () => {
 
 const cleanupOldEntries = async (userId: string) => {
     const now = new Date();
-    const weeklyCutoff = getWeeklyResetKey(subtractMonths(now, 3));
-    const monthlyCutoff = getMonthlyResetKey(subtractMonths(now, 3));
+    const retentionCutoff = subtractMonths(now, TODO_LIST_RETENTION_MONTHS);
+    const weeklyCutoff = getWeeklyResetKey(retentionCutoff);
+    const monthlyCutoff = getMonthlyResetKey(retentionCutoff);
 
     await Promise.all([
         supabase
@@ -380,7 +383,9 @@ export const saveCalendarEvents = async (monthKey: string, events: TodoListEvent
     await cleanupOldEntries(userId);
 };
 
-export const loadWeeklyBossHistory = async (months: number = 3) => {
+export const loadWeeklyBossHistory = async (
+    months: number = TODO_LIST_RETENTION_MONTHS,
+) => {
     const userId = await requireUserId();
     const cutoff = getWeeklyResetKey(subtractMonths(new Date(), months));
     const { data, error } = await supabase
@@ -402,7 +407,9 @@ export const loadWeeklyBossHistory = async (months: number = 3) => {
     })) ?? [];
 };
 
-export const loadMonthlyBossHistory = async (months: number = 3) => {
+export const loadMonthlyBossHistory = async (
+    months: number = TODO_LIST_RETENTION_MONTHS,
+) => {
     const userId = await requireUserId();
     const cutoff = getMonthlyResetKey(subtractMonths(new Date(), months));
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- add a SQL script that installs a pg_cron job to purge todo list entries older than six months
- export a shared six-month retention constant and reuse it when pruning todo list data and default history ranges

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d629b72594832480473961c58ad16f