### PR TITLE
Display weekly range labels on weekly trend chart

### DIFF
--- a/src/app/(main)/todo_list/dashboard/page.tsx
+++ b/src/app/(main)/todo_list/dashboard/page.tsx
@@ -30,7 +30,7 @@ import {
     WeeklyBossHistoryEntry,
 } from "@/fetchs/todoList.fetch";
 import { useLanguage, useTranslations } from "@/providers/LanguageProvider";
-import { formatKstDateLabel, formatKstMonthLabel } from "@/utils/date";
+import { formatKstMonthLabel, formatKstWeekRangeLabel } from "@/utils/date";
 import { formatCurrencyWithFallback } from "@/utils/number";
 
 type WeeklyBossSummary = Record<string, boolean>;
@@ -133,7 +133,7 @@ const DashboardPage = () => {
                 0,
             );
             return {
-                period: formatKstDateLabel(entry.periodKey, language),
+                period: formatKstWeekRangeLabel(entry.periodKey, language),
                 cleared,
                 rewardBillions: reward / 1_000_000_000,
             };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -120,6 +120,29 @@ export const formatKstDateLabel = (dateKey: string, locale: string) => {
     }).format(date);
 };
 
+export const formatKstWeekRangeLabel = (dateKey: string, locale: string) => {
+    const [yearStr, monthStr, dayStr] = dateKey.split("-");
+    const year = Number(yearStr);
+    const month = Number(monthStr) - 1;
+    const day = Number(dayStr);
+
+    const start = new Date(Date.UTC(year, month, day));
+    const end = new Date(Date.UTC(year, month, day + 6));
+
+    const options: Intl.DateTimeFormatOptions = {
+        timeZone: "Asia/Seoul",
+        month: locale.startsWith("ko") ? "long" : "short",
+        day: "numeric",
+    };
+
+    const formatter = new Intl.DateTimeFormat(locale, options);
+
+    const startLabel = formatter.format(start);
+    const endLabel = formatter.format(end);
+
+    return `${startLabel} ~ ${endLabel}`;
+};
+
 export const formatRelativeFromNow = (isoDate: string, locale: string) => {
     const formatter = new Intl.RelativeTimeFormat(locale.startsWith("ko") ? "ko" : "en", { numeric: "auto" });
     const target = new Date(isoDate).getTime();


### PR DESCRIPTION
## Summary
- add a date utility that formats a weekly reset period as a start~end range
- update the todo list dashboard to show weekly ranges on the weekly trend chart axis

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6317e5fa483249258eddfe96bb969