### PR TITLE
Rename todo list table references

### DIFF
--- a/sql/todo_list_retention.sql
+++ b/sql/todo_list_retention.sql
@@ -10,7 +10,7 @@ security definer
 set search_path = public, pg_temp
 as $$
 begin
-    delete from public.todo_list_entries as entries
+    delete from public.todo_list as entries
     where entries.category in ('weekly_boss', 'monthly_boss', 'memo', 'calendar')
       and coalesce(
             entries.updated_at,

--- a/src/fetchs/todoList.fetch.ts
+++ b/src/fetchs/todoList.fetch.ts
@@ -62,7 +62,7 @@ type TodoListRow = {
     updated_at?: string | null;
 };
 
-const TABLE = "todo_list_entries";
+const TABLE = "todo_list";
 
 const generateId = () =>
     typeof crypto !== "undefined" && "randomUUID" in crypto


### PR DESCRIPTION
## Summary
- update the todo list fetcher to use the renamed `todo_list` table
- update the retention cleanup SQL script to delete from the new table name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65a10b0e083249546b7f15d91799e