### PR TITLE
Fix duplicate event toast and update symbol reset text

### DIFF
--- a/src/constants/i18n/ko.ts
+++ b/src/constants/i18n/ko.ts
@@ -122,7 +122,7 @@ export const ko = {
             regions: {
                 "arcane-river": {
                     title: "아케인 리버",
-                    description: "일일 심볼 퀘스트는 매주 목요일 00시에 초기화돼요.",
+                    description: "일일 심볼 퀘스트는 매일 밤 12시에 초기화돼요.",
                 },
                 grandis: {
                     title: "그란디스",


### PR DESCRIPTION
## Summary
- update the Arcane River symbol description to note the daily midnight reset
- refactor calendar event persistence to avoid duplicate toasts when creating events
- ensure event updates and removals persist without side effects in state setters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d672f826d883248776b8b3a1dff9c9